### PR TITLE
DRAFT: apply blob tiling using tile types rather than spriteID lookups

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,6 +114,7 @@ func Init() {
 	input.Init(win.Window)
 	sound.Init()
 	spriteloader.InitSpriteloader(&win)
+	world.RegisterTileTypes()
 	spriteloader.DEBUG = false
 	item.InitWorldItem()
 	ui.InitTextRendering()

--- a/models/player.go
+++ b/models/player.go
@@ -1,8 +1,6 @@
 package models
 
 import (
-	"fmt"
-
 	"github.com/go-gl/mathgl/mgl32"
 
 	"github.com/skycoin/cx-game/camera"
@@ -93,7 +91,6 @@ func (player *Player) FixedTick(planet *world.Planet) {
 			// fmt.Println(player.Vel.X)
 		}
 	}
-	fmt.Println(player.Vel.X)
 	player.Vel.X = utility.ClampF(player.Vel.X, -player.MovementMeta.MovSpeed*player.ActiveMovementType.GetMovementSpeedModifier(), player.MovementMeta.MovSpeed*player.ActiveMovementType.GetMovementSpeedModifier())
 	player.MovementAfterTick(planet)
 }

--- a/spriteloader/blobsprites/blobsprites.go
+++ b/spriteloader/blobsprites/blobsprites.go
@@ -7,10 +7,11 @@ import (
 	"github.com/skycoin/cx-game/spriteloader"
 )
 
-var allBlobSprites = make(map[uint32]([]uint32))
-var nextBlobSpriteId = uint32(1)
+type BlobSpritesID uint32
+var allBlobSprites = make(map[BlobSpritesID]([]uint32))
+var nextBlobSpriteId = BlobSpritesID(1)
 
-func LoadBlobSprites(fname string) uint32 {
+func LoadBlobSprites(fname string) BlobSpritesID {
 	spritesheetId := spriteloader.LoadSpriteSheetByColRow(
 		fname, blob.BlobSheetHeight, blob.BlobSheetWidth )
 	blobSprites := []uint32{}
@@ -27,6 +28,6 @@ func LoadBlobSprites(fname string) uint32 {
 	return blobSpriteId
 }
 
-func GetBlobSpritesById(blobSpriteID uint32) []uint32 {
-	return allBlobSprites[blobSpriteID]
+func GetBlobSpritesById(id BlobSpritesID) []uint32 {
+	return allBlobSprites[id]
 }

--- a/ui/dev-paletes.go
+++ b/ui/dev-paletes.go
@@ -8,28 +8,30 @@ import (
 func NewDevTilePaleteSelector() TilePaletteSelector {
 	selector := MakeTilePaleteSelector(11,11)
 
+	/*
 	// solid tiles
 	selector.AddTile(
 		world.Tile {
-			TileType: world.TileTypeNormal,
+			TileCategory: world.TileCategoryNormal,
 			SpriteID: uint32(spriteloader.GetSpriteIdByName("Bedrock")),
 		},
 		0,1, world.TopLayer,
 	)
 	selector.AddTile(
 		world.Tile {
-			TileType: world.TileTypeNormal,
+			TileCategory: world.TileCategoryNormal,
 			SpriteID: uint32(spriteloader.GetSpriteIdByName("Stone")),
 		},
 		0,2, world.TopLayer,
 	)
 	selector.AddTile(
 		world.Tile {
-			TileType: world.TileTypeNormal,
+			TileCategory: world.TileCategoryNormal,
 			SpriteID: uint32(spriteloader.GetSpriteIdByName("Dirt")),
 		},
 		0,3, world.TopLayer,
 	)
+	*/
 
 	// mid-layer objects
 	// TODO: share texture resources between world and UI
@@ -39,7 +41,7 @@ func NewDevTilePaleteSelector() TilePaletteSelector {
 		LoadSprites(foregroundTilesSpritesheetId,"bluelab",6,3,15,3)
 	selector.AddMultiTile(
 		world.MultiTile {
-			Width: 10, Height: 1, TileType: world.TileTypeNormal,
+			Width: 10, Height: 1, TileCategory: world.TileCategoryNormal,
 			SpriteIDs: blueLabSpriteIds,
 			Name: "dev multi tile",
 		},

--- a/ui/tile-palette-selector.go
+++ b/ui/tile-palette-selector.go
@@ -61,7 +61,7 @@ func (selector *TilePaletteSelector) IsMultiTileSelected() bool {
 	if !selector.Visible() {
 		return false
 	}
-	return selector.SelectedTile().TileType == world.TileTypeMulti
+	return selector.SelectedTile().TileCategory == world.TileCategoryMulti
 }
 
 const selectorSize = 5
@@ -127,7 +127,7 @@ func (selector *TilePaletteSelector) Draw(ctx render.Context) {
 				Mul4(mgl32.Scale3D(1-spacing, 1-spacing, 1))
 
 			// TODO add a custom texture for drawing air
-			if tile.TileType != world.TileTypeNone {
+			if tile.TileCategory != world.TileCategoryNone {
 				spriteloader.DrawSpriteQuadContext(render.Context{
 					World:      tileWorldTransform,
 					Projection: ctx.Projection,

--- a/world/blobtilecreator.go
+++ b/world/blobtilecreator.go
@@ -1,0 +1,40 @@
+package world
+
+import (
+	"github.com/skycoin/cx-game/render/blob"
+	"github.com/skycoin/cx-game/spriteloader/blobsprites"
+)
+
+type BlobTileCreator struct {
+	name string
+	blobSpritesId blobsprites.BlobSpritesID
+	TileTypeID TileTypeID
+}
+
+func NewBlobTileCreator(
+		name string, blobSpritesId blobsprites.BlobSpritesID,
+) *BlobTileCreator {
+	return &BlobTileCreator { name: name, blobSpritesId: blobSpritesId }
+}
+
+func (creator BlobTileCreator) blobSprites() []uint32 {
+	return blobsprites.GetBlobSpritesById(creator.blobSpritesId)
+}
+
+func (creator BlobTileCreator) CreateTile(neighbours blob.Neighbours) Tile {
+	tile := Tile{}
+	creator.UpdateTile(&tile,neighbours)
+	return tile
+}
+
+func (creator BlobTileCreator) UpdateTile(
+		tile *Tile, neighbours blob.Neighbours,
+) {
+	blobSpriteIdx := blob.ApplyBlobTiling(neighbours)
+	*tile =  Tile {
+		SpriteID: creator.blobSprites()[blobSpriteIdx],
+		Name: creator.name,
+		TileCategory: TileCategoryNormal,
+		TileTypeID: creator.TileTypeID,
+	}
+}

--- a/world/devplanet.go
+++ b/world/devplanet.go
@@ -30,7 +30,7 @@ func NewDevPlanet() *Planet {
 		for y := 4; y < 6; y++ {
 			tileIdx := planet.GetTileIndex(x, y)
 			planet.Layers.Top[tileIdx] = Tile{
-				TileType: TileTypeNormal,
+				TileCategory: TileCategoryNormal,
 				SpriteID: uint32(spriteloader.GetSpriteIdByName("Dirt")),
 			}
 		}
@@ -40,7 +40,7 @@ func NewDevPlanet() *Planet {
 		for y := 2; y < 4; y++ {
 			tileIdx := planet.GetTileIndex(x, y)
 			planet.Layers.Top[tileIdx] = Tile{
-				TileType: TileTypeNormal,
+				TileCategory: TileCategoryNormal,
 				SpriteID: uint32(spriteloader.GetSpriteIdByName("Stone")),
 			}
 		}
@@ -50,7 +50,7 @@ func NewDevPlanet() *Planet {
 		for y := 0; y < 2; y++ {
 			tileIdx := planet.GetTileIndex(x, y)
 			planet.Layers.Top[tileIdx] = Tile{
-				TileType: TileTypeNormal,
+				TileCategory: TileCategoryNormal,
 				SpriteID: uint32(spriteloader.GetSpriteIdByName("Bedrock")),
 			}
 		}
@@ -58,29 +58,29 @@ func NewDevPlanet() *Planet {
 
 	// DEBUG: tiles to test collision and physics
 	*planet.GetTopLayerTile(27, 7) = Tile{
-		TileType: TileTypeNormal,
+		TileCategory: TileCategoryNormal,
 		SpriteID: uint32(spriteloader.GetSpriteIdByName("Stone")),
 	}
 	*planet.GetTopLayerTile(25, 5) = Tile{
-		TileType: TileTypeNone,
+		TileCategory: TileCategoryNone,
 		SpriteID: uint32(spriteloader.GetSpriteIdByName("Dirt")),
 	}
 
 	// wall to test
 	for i := 6; i < 35; i++ {
 		*planet.GetTopLayerTile(10, i) = Tile{
-			TileType: TileTypeNormal,
+			TileCategory: TileCategoryNormal,
 			SpriteID: uint32(spriteloader.GetSpriteIdByName(("Stone"))),
 		}
 		*planet.GetTopLayerTile(5, i) = Tile{
-			TileType: TileTypeNormal,
+			TileCategory: TileCategoryNormal,
 			SpriteID: uint32(spriteloader.GetSpriteIdByName(("Stone"))),
 		}
 	}
 
 	devMultiTile := MultiTile{
 		Width: 10, Height: 1,
-		TileType:  TileTypeNormal,
+		TileCategory:  TileCategoryNormal,
 		SpriteIDs: blueLabSpriteIds,
 		Name:      "dev multi tile",
 	}

--- a/world/generate.go
+++ b/world/generate.go
@@ -5,8 +5,8 @@ import (
 
 	perlin "github.com/skycoin/cx-game/procgen"
 	"github.com/skycoin/cx-game/cxmath"
-	"github.com/skycoin/cx-game/spriteloader"
-	"github.com/skycoin/cx-game/spriteloader/blobsprites"
+	//"github.com/skycoin/cx-game/spriteloader"
+	//"github.com/skycoin/cx-game/spriteloader/blobsprites"
 )
 
 // TODO shove in .yaml file
@@ -38,6 +38,26 @@ func (planet *Planet) placeLayer(
 	return positions
 }
 
+func (planet *Planet) placeLayerTileType(
+	tileTypeID TileTypeID, depth,noiseScale float32,
+) []cxmath.Vec2i {
+	positions := []cxmath.Vec2i {}
+	perlin := perlin.NewPerlin2D(rand.Int63(), int(planet.Width), xs, 256)
+	for x:=int32(0); x<planet.Width; x++ {
+		noiseSample := perlin.Noise(float32(x), 0, persistence, lacunarity, 8)
+		height := int(depth+noiseSample*noiseScale)
+		for i:=0; i<height; i++ {
+			y := planet.GetHeight(int(x)) + 1
+			planet.PlaceTileType(tileTypeID,int(x),int(y))
+			//tile := tiles[rand.Intn(len(tiles))]
+			//y := planet.placeTileOnTop(int(x),tile)
+			positions = append(positions, cxmath.Vec2i { x,int32(y) } )
+			//planet.placeTileType(int(x),int(y), 
+		}
+	}
+	return positions
+}
+
 const oreLacunarity = lacunarity*50
 func (planet *Planet) placeOres(tile Tile, threshold float32) {
 	perlin := perlin.NewPerlin2D(rand.Int63(), int(planet.Width), xs, 256)
@@ -62,8 +82,9 @@ func (planet *Planet) placeBgTile(tile Tile, pos cxmath.Vec2i) {
 
 func GeneratePlanet() *Planet {
 	planet := NewPlanet(100, 100)
-	oreSheetId := spriteloader.
-		LoadSpriteSheetByColRow("./assets/tile/ores-stone.png",3,4)
+	//oreSheetId := spriteloader.
+//		LoadSpriteSheetByColRow("./assets/tile/ores-stone.png",3,4)
+	/*
 	spriteloader.
 		LoadSingleSprite("./assets/tile/dirt.png", "Dirt")
 	spriteloader.
@@ -82,32 +103,35 @@ func GeneratePlanet() *Planet {
 		blobsprites.LoadBlobSprites("./assets/tile/Tiles_1_v1.png")
 	dirtWallBlobSpritesId :=
 		blobsprites.LoadBlobSprites("./assets/tile/Wall_1.png")
+	
+	// TODO re-enable blob sprites
+	_ = dirtBlobSpritesId
+	_ = altDirtBlobSpritesId
+	_ = dirtWallBlobSpritesId
 
 	dirt := Tile {
-		TileType: TileTypeNormal,
+		TileCategory: TileCategoryNormal,
 		SpriteID: uint32(spriteloader.GetSpriteIdByName("Dirt")),
 		Name: "Dirt",
-		IsBlob: true,
-		BlobSpriteID: dirtBlobSpritesId,
 	}
 	altDirt := dirt
-	altDirt.BlobSpriteID = altDirtBlobSpritesId
+	_ = altDirt
 	stone := Tile {
-		TileType: TileTypeNormal,
+		TileCategory: TileCategoryNormal,
 		SpriteID: uint32(spriteloader.GetSpriteIdByName("Stone")),
 		Name: "Stone",
 	}
 	bedrock := Tile {
-		TileType: TileTypeNormal,
+		TileCategory: TileCategoryNormal,
 		SpriteID: uint32(spriteloader.GetSpriteIdByName("Bedrock")),
 		Name: "Bedrock",
 	}
 	purpleOre := Tile {
-		TileType: TileTypeNormal,
+		TileCategory: TileCategoryNormal,
 		SpriteID:  uint32(spriteloader.GetSpriteIdByName("Big Gold")),
 	}
 	blueOre := Tile {
-		TileType: TileTypeNormal,
+		TileCategory: TileCategoryNormal,
 		SpriteID: uint32(spriteloader.GetSpriteIdByName("Ruby Pentagon")),
 	}
 
@@ -116,17 +140,19 @@ func GeneratePlanet() *Planet {
 
 	// todo make dirt wall look different
 	dirtWall := Tile {
-		TileType: TileTypeNormal,
+		TileCategory: TileCategoryNormal,
 		Name: "Dirt Wall",
-		IsBlob: true,
-		BlobSpriteID: dirtWallBlobSpritesId,
 	}
-	dirtPositions := planet.placeLayer([]Tile{dirt,altDirt}, 4,1)
-	for _,pos := range dirtPositions { planet.placeBgTile(dirtWall, pos) }
-	for _,pos := range stonePositions { planet.placeBgTile(dirtWall, pos) }
+	*/
+	planet.placeLayerTileType(bedrockTileTypeID, 4,1)
+	stonePositions := planet.placeLayerTileType(stoneTileTypeID, 8,2)
+	dirtPositions := planet.placeLayerTileType(dirtTileTypeID, 4,1)
 
-	planet.placeOres(purpleOre, 0.6)
-	planet.placeOres(blueOre, 0.7)
+	//for _,pos := range dirtPositions { planet.placeBgTile(dirtWall, pos) }
+	//for _,pos := range stonePositions { planet.placeBgTile(dirtWall, pos) }
+	_ = dirtPositions; _ = stonePositions
+	//jplanet.placeOres(purpleOre, 0.6)
+	//planet.placeOres(blueOre, 0.7)
 	
 	return planet
 }

--- a/world/tile.go
+++ b/world/tile.go
@@ -4,46 +4,44 @@ import (
 	"fmt"
 )
 
-type TileType uint32
+type TileCategory uint32
 
 const (
-	TileTypeNone TileType = iota
-	TileTypeNormal
-	TileTypeMulti
-	TileTypeChild
+	TileCategoryNone TileCategory = iota
+	TileCategoryNormal
+	TileCategoryMulti
+	TileCategoryChild
 )
 
-func (tt TileType) ShouldRender() bool {
-	return tt!=TileTypeNone
+func (tt TileCategory) ShouldRender() bool {
+	return tt!=TileCategoryNone
 }
 
 type Tile struct {
 	SpriteID uint32
-	TileType TileType
+	TileCategory TileCategory
+	TileTypeID TileTypeID
 	Name     string
 	OffsetX  int8
 	OffsetY  int8
 	Durability int8
-
-	IsBlob   bool
-	BlobSpriteID uint32
 }
 
 func NewEmptyTile() Tile {
-	return Tile {TileType: TileTypeNone}
+	return Tile {TileCategory: TileCategoryNone}
 }
 
 type MultiTile struct {
 	Width     int
 	Height    int
-	TileType  TileType
+	TileCategory  TileCategory
 	SpriteIDs []uint32
 	Name      string
 }
 
 // gets the base/root/master tile which controls the multi-tile
 func (mt MultiTile) Root() Tile {
-	return Tile { SpriteID: mt.SpriteIDs[0], TileType: TileTypeMulti }
+	return Tile { SpriteID: mt.SpriteIDs[0], TileCategory: TileCategoryMulti }
 }
 
 func (mt MultiTile) Area() int {
@@ -57,7 +55,7 @@ func (mt MultiTile) Tiles() []Tile {
 		y := idx / mt.Width
 		x := idx % mt.Width
 		tiles[idx] = Tile {
-			TileType: TileTypeChild,
+			TileCategory: TileCategoryChild,
 			SpriteID: mt.SpriteIDs[idx],
 			Name: fmt.Sprintf("%s (child [%d,%d])",mt.Name,x,y),
 			OffsetX: int8(x),

--- a/world/tiletype.go
+++ b/world/tiletype.go
@@ -1,0 +1,43 @@
+package world
+
+import (
+	"github.com/skycoin/cx-game/render/blob"
+)
+
+type TileCreator func(neighbours blob.Neighbours) Tile
+type TileUpdater func(tile *Tile, neighbours blob.Neighbours)
+type TileType struct {
+	Name string
+	Layer Layer
+	CreateTile TileCreator
+	UpdateTile TileUpdater 
+	Invulnerable bool
+}
+
+func NewTileType(name string, layer Layer, createTile TileCreator) TileType {
+	return TileType { Name: name, Layer: layer, CreateTile: createTile }
+}
+
+type TileTypeID uint32
+
+// add the null tile type as first element such that tileTypes[0] is empty
+var tileTypes = make([]TileType,1)
+
+func RegisterTileType(tileType TileType) TileTypeID {
+	id := len(tileTypes)
+	tileTypes = append(tileTypes, tileType)
+	return TileTypeID(id)
+}
+
+func NextTileTypeID() TileTypeID {
+	return TileTypeID(len(tileTypes))
+}
+
+func GetTileTypeByID(id TileTypeID) (TileType,bool) {
+	ok :=  id >=1 && id < TileTypeID(len(tileTypes))
+	if ok {
+		return tileTypes[id],true
+	} else {
+		return TileType{},false
+	}
+}

--- a/world/tiletypes.go
+++ b/world/tiletypes.go
@@ -1,0 +1,70 @@
+package world
+
+import (
+	"github.com/skycoin/cx-game/spriteloader"
+	"github.com/skycoin/cx-game/render/blob"
+	"github.com/skycoin/cx-game/spriteloader/blobsprites"
+)
+
+var (
+	emptyTileTypeID TileTypeID
+	dirtTileTypeID TileTypeID
+	stoneTileTypeID TileTypeID
+	bedrockTileTypeID TileTypeID
+)
+
+func RegisterTileTypes() {
+	RegisterEmptyTileType()
+	RegisterDirtTileType()
+	RegisterStoneTileType()
+	RegisterBedrockTileType()
+}
+
+func RegisterEmptyTileType() {
+	emptyTileTypeID = RegisterTileType(TileType {
+		Name: "Air",
+		CreateTile: func (n blob.Neighbours) Tile {
+			return Tile {}
+		},
+		UpdateTile: func (t *Tile,n blob.Neighbours) {},
+	})
+}
+
+func RegisterSimpleTileType(name string, spriteID uint32) TileTypeID {
+	id := NextTileTypeID()
+	return RegisterTileType(TileType {
+		Name: name,
+		Layer: TopLayer,
+		CreateTile: func (n blob.Neighbours) Tile { return Tile {
+			SpriteID: spriteID,
+			Name: name,
+			TileCategory: TileCategoryNormal,
+			TileTypeID: id,
+			Durability: 1,
+		} },
+		UpdateTile: func (t *Tile,n blob.Neighbours) {},
+	})
+}
+
+func RegisterStoneTileType() {
+	spriteID :=
+		spriteloader.LoadSingleSprite("./assets/tile/stone.png","Stone")
+	stoneTileTypeID = RegisterSimpleTileType("Stone",uint32(spriteID))
+}
+
+func RegisterBedrockTileType() {
+	spriteID :=
+		spriteloader.LoadSingleSprite("./assets/tile/bedrock.png","Stone")
+	bedrockTileTypeID = RegisterSimpleTileType("Bedrock",uint32(spriteID))
+	tileTypes[bedrockTileTypeID].Invulnerable = true
+}
+
+func RegisterDirtTileType() {
+	blobSpritesId :=
+		blobsprites.LoadBlobSprites("./assets/tile/Tiles_1.png")
+	creator := NewBlobTileCreator("Dirt", blobSpritesId)
+	creator.TileTypeID = NextTileTypeID()
+	tileType := NewTileType("Dirt", TopLayer, creator.CreateTile)
+	tileType.UpdateTile = creator.UpdateTile
+	dirtTileTypeID = RegisterTileType(tileType)
+}


### PR DESCRIPTION
* Rename old `TileType` to `TileCategory` to make way for actual tile types
* Apply blob tiling on placement / neighbour placement other than pre-draw
* Formalize system connecting dropped items with tile 
* Bedrock cannot be mined