### PR TITLE
formalize types for SpriteID and SpritesheetID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 
 # Dependency directories (remove the comment below to include it)
 vendor/
+
+main

--- a/cxecs/devcomponents/rendercomponent.go
+++ b/cxecs/devcomponents/rendercomponent.go
@@ -1,5 +1,9 @@
 package components
 
+import (
+	"github.com/skycoin/cx-game/spriteloader"
+)
+
 type RenderComponent struct {
-	SpriteId int
+	SpriteId spriteloader.SpriteID
 }

--- a/cxecs/devsystems/rendersystem.go
+++ b/cxecs/devsystems/rendersystem.go
@@ -51,7 +51,7 @@ func (rs *RenderSystem) Update(dt float32) {
 			entity.Position.Y,
 			entity.Size.X,
 			entity.Size.Y,
-			int(entity.SpriteId),
+			(entity.SpriteId),
 		)
 	}
 	// fmt.Println("render system")

--- a/enemies/enemies.go
+++ b/enemies/enemies.go
@@ -24,7 +24,7 @@ func InitBasicEnemies() {
 }
 
 // TODO load an actual sprite here
-var basicEnemySpriteId int
+var basicEnemySpriteId spriteloader.SpriteID
 var basicEnemyMovSpeed = float32(1)
 var basicEnemies = []*Enemy{}
 

--- a/item/inventory.go
+++ b/item/inventory.go
@@ -149,7 +149,7 @@ func (inventory Inventory) DrawSlot(
 	// TODO write number for quantity
 	if slot.Quantity > 0 {
 		spriteId := itemTypes[slot.ItemTypeID].SpriteID
-		spriteloader.DrawSpriteQuadContext(itemCtx, int(spriteId))
+		spriteloader.DrawSpriteQuadContext(itemCtx, (spriteId))
 
 		textCtx := itemCtx.PushLocal(
 			mgl32.Translate3D(0.5,-0.05,0).

--- a/item/item.go
+++ b/item/item.go
@@ -7,10 +7,11 @@ import (
 	"github.com/skycoin/cx-game/camera"
 	"github.com/skycoin/cx-game/world"
 	"github.com/skycoin/cx-game/models"
+	"github.com/skycoin/cx-game/spriteloader"
 )
 
 type ItemType struct {
-	SpriteID int
+	SpriteID spriteloader.SpriteID
 	Name string
 
 	Use func(ItemUseInfo)
@@ -47,7 +48,7 @@ var itemTypes = make(map[ItemTypeID]*ItemType)
 
 var nextItemTypeID = ItemTypeID(1)
 
-func NewItemType(SpriteID int) ItemType {
+func NewItemType(SpriteID spriteloader.SpriteID) ItemType {
 	return ItemType {
 		SpriteID: SpriteID,
 		Name: "untitled",
@@ -70,7 +71,7 @@ func GetItemTypeIdForTile(tile world.Tile) ItemTypeID {
 	itemTypeID,ok := tileTypeIDsToItemTypeIDs[tile.TileTypeID]
 	if ok { return itemTypeID }
 
-	itemType := NewItemType(int(tile.SpriteID))
+	itemType := NewItemType((tile.SpriteID))
 	itemType.Name = tile.Name
 	itemType.Use = func(info ItemUseInfo) {
 		worldCoords := info.WorldCoords()

--- a/models/cat_black.go
+++ b/models/cat_black.go
@@ -26,7 +26,7 @@ type CatBlack struct {
 	XVelocity, YVelocity float32
 	movSpeed             float32
 	jumpSpeed            float32
-	SpriteSheetId        int
+	SpriteSheetId        spriteloader.SpritesheetID
 }
 
 const (
@@ -38,8 +38,10 @@ const (
 
 var stopPlay chan bool
 
-// private method
-func play(action int, fcount int, lwindow *glfw.Window, lspriteSheetId int) {
+func play(
+		action int, fcount int, lwindow *glfw.Window, 
+		lspriteSheetId spriteloader.SpritesheetID,
+) {
 	stopPlay = make(chan bool)
 	j := 0
 	for {

--- a/models/player.go
+++ b/models/player.go
@@ -11,6 +11,7 @@ import (
 	"github.com/skycoin/cx-game/physics/movement"
 	"github.com/skycoin/cx-game/utility"
 	"github.com/skycoin/cx-game/world"
+	"github.com/skycoin/cx-game/spriteloader"
 )
 
 type Player struct {
@@ -21,8 +22,8 @@ type Player struct {
 	// ImageSize       image.Point
 	helmId        int
 	suitId        int
-	helmSpriteIds [4]int
-	suitSpriteIds [4]int
+	helmSpriteIds [4]spriteloader.SpriteID
+	suitSpriteIds [4]spriteloader.SpriteID
 	XDirection    float32 // 1 when facing right, -1 when facing left
 }
 

--- a/models/player_outfit.go
+++ b/models/player_outfit.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	helmSpriteSheetId int
-	suitSpriteSheetId int
+	helmSpriteSheetId spriteloader.SpritesheetID
+	suitSpriteSheetId spriteloader.SpritesheetID
 )
 
 const (

--- a/particles/particles.go
+++ b/particles/particles.go
@@ -16,7 +16,7 @@ type Particle struct {
 	ID               int32
 	ParticleMetaType int32
 	Type             int32
-	Sprite           uint32
+	Sprite           spriteloader.SpriteID
 	Size             float32
 	Verlet           verlet.Verlet2
 	TimeToLive       float32
@@ -123,7 +123,7 @@ func DrawChunkParticle(particle Particle, ctx render.Context) {
 	gl.DrawArrays(gl.TRIANGLES,0,6) // draw quad
 }
 
-func CreateTileChunks(x,y float32, TileSpriteID uint32) {
+func CreateTileChunks(x,y float32, TileSpriteID spriteloader.SpriteID) {
 	for i:=0; i<chunksPerChip; i++ {
 		particle := Particle {
 			ID: rand.Int31(),

--- a/spriteloader/blobsprites/blobsprites.go
+++ b/spriteloader/blobsprites/blobsprites.go
@@ -8,13 +8,13 @@ import (
 )
 
 type BlobSpritesID uint32
-var allBlobSprites = make(map[BlobSpritesID]([]uint32))
+var allBlobSprites = make(map[BlobSpritesID]([]spriteloader.SpriteID))
 var nextBlobSpriteId = BlobSpritesID(1)
 
 func LoadBlobSprites(fname string, w,h int) BlobSpritesID {
 	spritesheetId := spriteloader.LoadSpriteSheetByColRow(
 		fname, h, w )
-	blobSprites := []uint32{}
+	blobSprites := []spriteloader.SpriteID{}
 	for idx:=0; idx < w*h; idx++ {
 		y := idx / w
 		x := idx % w
@@ -39,6 +39,6 @@ func LoadSimpleBlobSprites(fname string) BlobSpritesID {
 	)
 }
 
-func GetBlobSpritesById(id BlobSpritesID) []uint32 {
+func GetBlobSpritesById(id BlobSpritesID) []spriteloader.SpriteID {
 	return allBlobSprites[id]
 }

--- a/starfield/starfield.go
+++ b/starfield/starfield.go
@@ -73,7 +73,7 @@ type Star struct {
 	X             float32
 	Y             float32
 	Size          float32
-	SpriteId      int
+	SpriteId      spriteloader.SpriteID
 	GradientValue float32
 	GradientId    int
 	Depth         float32

--- a/ui/tile-palette-selector.go
+++ b/ui/tile-palette-selector.go
@@ -131,7 +131,7 @@ func (selector *TilePaletteSelector) Draw(ctx render.Context) {
 				spriteloader.DrawSpriteQuadContext(render.Context{
 					World:      tileWorldTransform,
 					Projection: ctx.Projection,
-				}, int(tile.SpriteID))
+				}, (tile.SpriteID))
 			}
 		}
 	}

--- a/world/autoplacer.go
+++ b/world/autoplacer.go
@@ -3,6 +3,7 @@ package world
 import (
 	"github.com/skycoin/cx-game/render/blob"
 	"github.com/skycoin/cx-game/spriteloader/blobsprites"
+	"github.com/skycoin/cx-game/spriteloader"
 )
 
 // place tiles for a given tiletype using an auto-tiling mechanism
@@ -13,7 +14,7 @@ type AutoPlacer struct {
 	TilingType blob.TilingType
 }
 
-func (ap AutoPlacer) blobSprites() []uint32 {
+func (ap AutoPlacer) blobSprites() []spriteloader.SpriteID {
 	return blobsprites.GetBlobSpritesById(ap.blobSpritesId)
 }
 

--- a/world/devplanet.go
+++ b/world/devplanet.go
@@ -31,7 +31,7 @@ func NewDevPlanet() *Planet {
 			tileIdx := planet.GetTileIndex(x, y)
 			planet.Layers.Top[tileIdx] = Tile{
 				TileCategory: TileCategoryNormal,
-				SpriteID: uint32(spriteloader.GetSpriteIdByName("Dirt")),
+				SpriteID: (spriteloader.GetSpriteIdByName("Dirt")),
 			}
 		}
 	}
@@ -41,7 +41,7 @@ func NewDevPlanet() *Planet {
 			tileIdx := planet.GetTileIndex(x, y)
 			planet.Layers.Top[tileIdx] = Tile{
 				TileCategory: TileCategoryNormal,
-				SpriteID: uint32(spriteloader.GetSpriteIdByName("Stone")),
+				SpriteID: (spriteloader.GetSpriteIdByName("Stone")),
 			}
 		}
 	}
@@ -51,7 +51,7 @@ func NewDevPlanet() *Planet {
 			tileIdx := planet.GetTileIndex(x, y)
 			planet.Layers.Top[tileIdx] = Tile{
 				TileCategory: TileCategoryNormal,
-				SpriteID: uint32(spriteloader.GetSpriteIdByName("Bedrock")),
+				SpriteID: (spriteloader.GetSpriteIdByName("Bedrock")),
 			}
 		}
 	}
@@ -59,22 +59,22 @@ func NewDevPlanet() *Planet {
 	// DEBUG: tiles to test collision and physics
 	*planet.GetTopLayerTile(27, 7) = Tile{
 		TileCategory: TileCategoryNormal,
-		SpriteID: uint32(spriteloader.GetSpriteIdByName("Stone")),
+		SpriteID: (spriteloader.GetSpriteIdByName("Stone")),
 	}
 	*planet.GetTopLayerTile(25, 5) = Tile{
 		TileCategory: TileCategoryNone,
-		SpriteID: uint32(spriteloader.GetSpriteIdByName("Dirt")),
+		SpriteID: (spriteloader.GetSpriteIdByName("Dirt")),
 	}
 
 	// wall to test
 	for i := 6; i < 35; i++ {
 		*planet.GetTopLayerTile(10, i) = Tile{
 			TileCategory: TileCategoryNormal,
-			SpriteID: uint32(spriteloader.GetSpriteIdByName(("Stone"))),
+			SpriteID: (spriteloader.GetSpriteIdByName(("Stone"))),
 		}
 		*planet.GetTopLayerTile(5, i) = Tile{
 			TileCategory: TileCategoryNormal,
-			SpriteID: uint32(spriteloader.GetSpriteIdByName(("Stone"))),
+			SpriteID: (spriteloader.GetSpriteIdByName(("Stone"))),
 		}
 	}
 

--- a/world/planet.go
+++ b/world/planet.go
@@ -78,19 +78,19 @@ func (planet *Planet) DrawLayer(tiles []Tile, cam *camera.Camera) {
 				spriteloader.DrawSpriteQuad(
 					float32(x)-cam.X, float32(y)-cam.Y,
 					1, 1,
-					int(tile.SpriteID),
+					(tile.SpriteID),
 				)
 				// TODO replace this with something more performant
 				// draw extra versions to achieve wrap around
 				spriteloader.DrawSpriteQuad(
 					float32(x-planet.Width)-cam.X, float32(y)-cam.Y,
 					1, 1,
-					int(tile.SpriteID),
+					(tile.SpriteID),
 				)
 				spriteloader.DrawSpriteQuad(
 					float32(x+planet.Width)-cam.X, float32(y)-cam.Y,
 					1, 1,
-					int(tile.SpriteID),
+					(tile.SpriteID),
 				)
 			}
 		}

--- a/world/tile.go
+++ b/world/tile.go
@@ -2,6 +2,8 @@ package world
 
 import (
 	"fmt"
+
+	"github.com/skycoin/cx-game/spriteloader"
 )
 
 type TileCategory uint32
@@ -18,7 +20,7 @@ func (tt TileCategory) ShouldRender() bool {
 }
 
 type Tile struct {
-	SpriteID uint32
+	SpriteID spriteloader.SpriteID
 	TileCategory TileCategory
 	TileTypeID TileTypeID
 	Name     string
@@ -35,7 +37,7 @@ type MultiTile struct {
 	Width     int
 	Height    int
 	TileCategory  TileCategory
-	SpriteIDs []uint32
+	SpriteIDs []spriteloader.SpriteID
 	Name      string
 }
 

--- a/world/tiletype.go
+++ b/world/tiletype.go
@@ -2,6 +2,7 @@ package world
 
 import (
 	"github.com/skycoin/cx-game/render/blob"
+	"github.com/skycoin/cx-game/spriteloader"
 )
 
 type Placer interface {
@@ -11,7 +12,7 @@ type Placer interface {
 
 // place tiles for a tiletype which has a single sprite
 type DirectPlacer struct {
-	SpriteID uint32
+	SpriteID spriteloader.SpriteID
 }
 func (placer DirectPlacer) CreateTile(
 	tt TileType,opts TileCreationOptions,

--- a/world/tiletypes.go
+++ b/world/tiletypes.go
@@ -36,7 +36,7 @@ func RegisterStoneTileType() {
 		spriteloader.LoadSingleSprite("./assets/tile/stone.png","Stone")
 	TileTypeIDs.Stone = RegisterTileType(TileType {
 		Name: "Stone",
-		Placer: DirectPlacer{SpriteID:uint32(spriteID)},
+		Placer: DirectPlacer{SpriteID:(spriteID)},
 		Layer: TopLayer,
 	})
 }
@@ -46,7 +46,7 @@ func RegisterBedrockTileType() {
 		spriteloader.LoadSingleSprite("./assets/tile/bedrock.png","Stone")
 	TileTypeIDs.Bedrock = RegisterTileType(TileType {
 		Name: "Bedrock",
-		Placer: DirectPlacer{SpriteID:uint32(spriteID)},
+		Placer: DirectPlacer{SpriteID:(spriteID)},
 		Layer: TopLayer,
 		Invulnerable: true,
 	})


### PR DESCRIPTION
Removes unnecessary casts to `int` and `uint32` when referring to IDs of Sprites and Spritesheets. Introduces the `SpriteID` and `SpritesheetID` types.