### PR TITLE
Add furniture

### DIFF
--- a/assets/sprite/containers.yaml
+++ b/assets/sprite/containers.yaml
@@ -14,6 +14,36 @@ sprites:
         left: 0
         top: 0
 
+    purplecanister:
+        unit: grid
+        left: 1
+        top: 0
+        
+    purplebutton:
+        unit: grid
+        left: 2
+        top: 0
+
+    redbutton:
+        unit: grid
+        left: 3
+        top: 0
+
+    crate:
+        unit: grid
+        left: 0
+        top: 1
+
+    crate-square-inset:
+        unit: grid
+        left: 1
+        top: 1
+
+    crate-heart-inset:
+        unit: grid
+        left: 2
+        top: 1
+
     ac-unit:
         unit: grid
         left: 0

--- a/assets/tile/furnitures.yaml
+++ b/assets/tile/furnitures.yaml
@@ -1,0 +1,59 @@
+---
+
+orangebucket:
+    sprite: orangebucket
+    durability: 20
+    width: 1
+    height: 1
+    layer: mid
+
+purplebutton:
+    sprite: purplebutton
+    durability: 20
+    width: 1
+    height: 1
+    layer: mid
+
+redbutton:
+    sprite: redbutton
+    durability: 20
+    width: 1
+    height: 1
+    layer: mid
+
+purplecanister:
+    sprite: purplecanister
+    durability: 20
+    width: 1
+    height: 1
+    layer: mid
+
+crate:
+    sprite: crate
+    durability: 20
+    width: 1
+    height: 1
+    layer: mid
+
+crate-square-inset:
+    sprite: crate-square-inset
+    durability: 20
+    width: 1
+    height: 1
+    layer: mid
+
+crate-heart-inset:
+    sprite: crate-heart-inset
+    durability: 20
+    width: 1
+    height: 1
+    layer: mid
+
+ac-unit:
+    sprite: ac-unit
+    durability: 20
+    width: 2
+    height: 1
+    layer: mid
+
+---

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"path/filepath"
+	"io/fs"
+	"strings"
+)
+
+// ext should look like ".yaml" or ".png" - dot must be included
+func FindPathsWithExt(root,ext string) []string {
+	paths := []string{}
+	filepath.Walk(
+		root,
+		func(path string, info fs.FileInfo, er error) error {
+			if strings.HasSuffix(path, ext) {
+				paths = append(paths, path)
+			}
+			return nil
+		},
+	)
+	return paths
+}

--- a/item/placement-grid.go
+++ b/item/placement-grid.go
@@ -43,7 +43,9 @@ type PositionedTileTypeID struct {
 
 func (p PositionedTileTypeID) Transform() mgl32.Mat4 {
 	translation := mgl32.Translate3D(
-		float32(p.Rect.Origin.X), -float32(p.Rect.Origin.Y), 0 )
+		float32(p.Rect.Size.X)/2-0.5+float32(p.Rect.Origin.X),
+		-1*(float32(p.Rect.Size.Y)/2-0.5+float32(p.Rect.Origin.Y)),
+		0 )
 	scale := mgl32.Scale3D(
 		float32(p.Rect.Size.X), float32(p.Rect.Size.Y), 1)
 	return translation.Mul4(scale)
@@ -92,9 +94,11 @@ func NewPlacementGrid() PlacementGrid {
 	return PlacementGrid { PositionedTileTypeIDs: []PositionedTileTypeID{} }
 }
 
+
 func (ig *PlacementGrid) Assemble(itemTypeIDs []ItemTypeID) {
-	tileTypeIDs := GetTileTypesIDsForItemTypeIDs(itemTypeIDs)
-	ig.PositionedTileTypeIDs = LayoutTiletypes(tileTypeIDs)
+	//tileTypeIDs := GetTileTypesIDsForItemTypeIDs(itemTypeIDs)
+	ids := world.AllTileTypeIDs()
+	ig.PositionedTileTypeIDs = LayoutTiletypes(ids)
 	//log.Printf("%+v",*ig)
 }
 

--- a/spriteloader/config.go
+++ b/spriteloader/config.go
@@ -207,11 +207,13 @@ func RegisterSpritesFromConfig(cfgPath string) []SpriteID {
 		offset := sprite.Transform.Col(2)
 		xScale := sprite.Transform.At(0,0)
 		yScale := sprite.Transform.At(1,1)
+		worldXScale := sprite.Model.At(0,0)
+		worldYScale := sprite.Model.At(1,1)
 
 		LoadSpriteF(
 			spriteloadersheet,
 			sprite.Name, offset.X(), offset.Y(),
-			xScale, yScale,
+			xScale, yScale, worldXScale, worldYScale,
 		)
 	}
 	return []SpriteID{}

--- a/world/draw.go
+++ b/world/draw.go
@@ -148,9 +148,13 @@ func (planet *Planet) drawSpritesheetBin(
 		y := positionedTile.Position.Y
 		meta := spriteloader.GetSpriteMetadata(tile.SpriteID)
 
-		worlds[instance] = mgl32.Translate3D(
-			camToCenterX+float32(x)-center, float32(y)-camY, 0,
+		translate := mgl32.Translate3D(
+			meta.WorldXScale/2-0.5+camToCenterX+float32(x)-center,
+			meta.WorldYScale/2-0.5+float32(y)-camY,
+			0,
 		)
+		scale := mgl32.Scale3D( meta.WorldXScale, meta.WorldYScale, 1)
+		worlds[instance] = translate.Mul4(scale)
 		texScales[instance] = mgl32.Vec2 { meta.ScaleX, meta.ScaleY }
 		// hack - fix translate*scale vs scale*translate mismatch
 		// between shader and spriteloader
@@ -198,7 +202,9 @@ func (planet *Planet) drawLiquidTiles(
 		meta := spriteloader.GetSpriteMetadata(tile.SpriteID)
 
 		worlds[instance] = mgl32.Translate3D(
-			camToCenterX+float32(x)-center, float32(y)-camY, 0,
+			camToCenterX+float32(x)-center, 
+			float32(y)-camY, 
+			0,
 		)
 		texScales[instance] = mgl32.Vec2 { meta.ScaleX, meta.ScaleY }
 		// hack - fix translate*scale vs scale*translate mismatch

--- a/world/init.go
+++ b/world/init.go
@@ -1,0 +1,5 @@
+package world
+
+func Init() {
+	RegisterTileTypes()
+}

--- a/world/tiletype.go
+++ b/world/tiletype.go
@@ -117,3 +117,12 @@ func (id TileTypeID) Get() *TileType {
 func AddDrop(id TileTypeID, drop Drop) {
 	tileTypes[id].Drops = append(tileTypes[id].Drops, drop)
 }
+
+// not including air
+func AllTileTypeIDs() []TileTypeID {
+	ids := make([]TileTypeID, 0,len(tileTypes))
+	for idx := TileTypeID(2) ; int(idx) < len(tileTypes) ; idx ++ {
+		ids = append(ids,idx)
+	}
+	return ids
+}

--- a/world/tiletypes.go
+++ b/world/tiletypes.go
@@ -5,6 +5,8 @@ import (
 	"log"
 
 	"github.com/go-yaml/yaml"
+
+	"github.com/skycoin/cx-game/config"
 	"github.com/skycoin/cx-game/render/blob"
 	"github.com/skycoin/cx-game/spriteloader"
 	"github.com/skycoin/cx-game/spriteloader/blobsprites"
@@ -18,6 +20,8 @@ type TileConfig struct {
 	Layer string `yaml:"layer"`
 	Invulnerable bool `yaml:"invulnerable"`
 	Category string `yaml:"category"`
+	Width int32 `yaml:"width"`
+	Height int32 `yaml:"height"`
 }
 
 func loadIDsFromSpritenames(names []string, n int) []blobsprites.BlobSpritesID {
@@ -87,6 +91,7 @@ func (config *TileConfig) TileType(name string, id TileTypeID) TileType {
 		Layer: LayerIDFromName(config.Layer),
 		Placer: config.Placer(name,id),
 		Invulnerable: config.Invulnerable,
+		Width: config.Width, Height: config.Height,
 	}
 }
 
@@ -105,20 +110,20 @@ func RegisterEmptyTileType() {
 	})
 }
 
-const tilesConfigPath = "./assets/tile/tiles.yaml"
-
 func RegisterConfigTileTypes() {
-	buf, err := os.ReadFile(tilesConfigPath)
-	if err != nil {
-		log.Fatalf("cannot read tile config at %s",tilesConfigPath)
+	paths := config.FindPathsWithExt("./assets/tile/", ".yaml")
+	for _,path := range paths {
+		buf, err := os.ReadFile(path)
+		if err != nil {
+			log.Fatalf("cannot read tile config at %s",path)
+		}
+		var configs TileConfigs
+		err = yaml.Unmarshal(buf,&configs)
+		if err != nil {
+			log.Fatalf("parse tile config %s: %v",path,err)
+		}
+		for name,config := range configs {
+			RegisterTileType(name, config.TileType(name,NextTileTypeID()))
+		}
 	}
-	var configs TileConfigs
-	err = yaml.Unmarshal(buf,&configs)
-	if err != nil {
-		log.Fatalf("parse tile config %s: %v",tilesConfigPath,err)
-	}
-	for name,config := range configs {
-		RegisterTileType(name, config.TileType(name,NextTileTypeID()))
-	}
-
 }

--- a/z_game/game/init.go
+++ b/z_game/game/init.go
@@ -70,7 +70,7 @@ func Init() {
 	spriteloader.InitSpriteloader(&win)
 	spriteloader.LoadSpritesFromConfigs()
 	anim.InitAnimatedSpriteLoader()
-	world.RegisterTileTypes()
+	world.Init()
 	item.InitWorldItem()
 	ui.Init()
 	particles.InitParticles()


### PR DESCRIPTION
closes #290 

![image](https://user-images.githubusercontent.com/8276517/128266367-cb6e6642-9031-4ab0-a12f-4d3df5cf0dfc.png)


Adds canisters/ac-unit etc. Some of these items are larger than 1x1.

# TODO
- restructure sprite drawing to reduce verbosity / hold a single source of truth

# Changes
- add furnitures
- fix item sprite rendering
- furniture slot has correct dimensions in placement grid
- load world dimensions from tile YAML
- populate placement grid with all tiletypes