### PR TITLE
Fix horizontal collisions

### DIFF
--- a/agents/types.go
+++ b/agents/types.go
@@ -68,7 +68,7 @@ func createSlime(opts AgentCreationOptions) *Agent {
 		HealthComponent: NewHealthComponent(5),
 		AnimationPlayback:  playback,
 	}
-	physics.RegisterBody(&agent.PhysicsState)
+	//physics.RegisterBody(&agent.PhysicsState)
 	return &agent
 }
 
@@ -88,7 +88,7 @@ func createSpiderDrill(opts AgentCreationOptions) *Agent {
 		HealthComponent: NewHealthComponent(5),
 		AnimationPlayback:  playback,
 	}
-	physics.RegisterBody(&agent.PhysicsState)
+	//physics.RegisterBody(&agent.PhysicsState)
 	return &agent
 }
 

--- a/components/agents/agent_ai/drilling.go
+++ b/components/agents/agent_ai/drilling.go
@@ -2,15 +2,27 @@ package agent_ai
 
 import (
 	"github.com/skycoin/cx-game/agents"
+	"github.com/skycoin/cx-game/constants"
 	"github.com/skycoin/cx-game/cxmath/math32"
 )
 
 const (
-	drillSpeed float32 = 1
+	drillSpeed float32 = 3
+	drillJumpSpeed float32 = 15
 )
 
 func AiHandlerDrill(agent *agents.Agent, ctx AiContext) {
 	directionX := math32.Sign(ctx.PlayerPos.X() - agent.PhysicsState.Pos.X)
 	agent.PhysicsState.Direction = directionX * -1
 	agent.PhysicsState.Vel.X = directionX * drillSpeed
+
+	doJump :=
+		agent.PhysicsState.Collisions.Horizontal() &&
+		agent.PhysicsState.IsOnGround()
+
+	if doJump {
+		agent.PhysicsState.Vel.Y = drillJumpSpeed
+	} else {
+		agent.PhysicsState.Vel.Y -= constants.Gravity*constants.TimeStep
+	}
 }

--- a/components/update.go
+++ b/components/update.go
@@ -38,14 +38,9 @@ func updateTimers(agents []*agents.Agent, dt float32) {
 }
 
 func FixedUpdate() {
-	//update health state first
 	agent_health.UpdateAgents(&currentWorld.Entities.Agents)
-	//update physics state second
 	agent_physics.UpdateAgents(currentWorld)
-
 	agent_ai.UpdateAgents(currentWorld, currentPlayer)
-
-	//update particles
 	particle_physics.Update(currentWorld)
 }
 

--- a/physics/body.go
+++ b/physics/body.go
@@ -2,7 +2,6 @@ package physics
 
 import (
 	"math"
-
 	"github.com/go-gl/mathgl/mgl32"
 
 	"github.com/skycoin/cx-game/cxmath"

--- a/physics/collisioninfo.go
+++ b/physics/collisioninfo.go
@@ -11,3 +11,7 @@ type CollisionInfo struct {
 func (c *CollisionInfo) Reset() {
 	c.Above, c.Below, c.Left, c.Right = false, false, false, false
 }
+
+func (c CollisionInfo) Horizontal() bool {
+	return c.Left || c.Right
+}


### PR DESCRIPTION
Due to agents accidentally being registered in the physics system twice, collision info was not accurate. To demonstrate horizontal collisions being detected correctly, the spider drill now jumps.

closes #282 