### PR TITLE
Scale sprites / tiles consistently

### DIFF
--- a/assets/sprite/containers.yaml
+++ b/assets/sprite/containers.yaml
@@ -1,54 +1,61 @@
 ---
 
-width: 128
-height: 96
-
-cellwidth: 32
-cellheight: 32
-
 name: containers
 
 sprites:
     orangebucket:
-        unit: grid
         left: 0
         top: 0
+        width: 2
+        height: 2
 
     purplecanister:
         unit: grid
-        left: 1
+        left: 2
         top: 0
+        width: 2
+        height: 2
         
     purplebutton:
         unit: grid
-        left: 2
+        left: 4
         top: 0
+        width: 2
+        height: 2
 
     redbutton:
         unit: grid
-        left: 3
+        left: 6
         top: 0
+        width: 2
+        height: 2
 
     crate:
         unit: grid
         left: 0
-        top: 1
+        top: 2
+        width: 2
+        height: 2
 
     crate-square-inset:
         unit: grid
-        left: 1
-        top: 1
+        left: 2
+        top: 2
+        width: 2
+        height: 2
 
     crate-heart-inset:
         unit: grid
-        left: 2
-        top: 1
+        left: 4
+        top: 2
+        width: 2
+        height: 2
 
     ac-unit:
         unit: grid
         left: 0
-        top: 2
-        width: 2
-        height: 1
+        top: 4
+        width: 3
+        height: 2
 
 ---

--- a/assets/sprite/furniture/decorations/spareSuit.yaml
+++ b/assets/sprite/furniture/decorations/spareSuit.yaml
@@ -1,7 +1,5 @@
 ---
 
 name: decorations/spare-suit
-modelwidth: 1
-modelheight: 2
 
 ---

--- a/constants/config.go
+++ b/constants/config.go
@@ -1,0 +1,6 @@
+package constants
+
+const (
+	// sprite size in pixels (maps to a single world unit)
+	DEFAULT_SPRITE_SIZE int = 16
+)

--- a/render/sprites.go
+++ b/render/sprites.go
@@ -27,3 +27,7 @@ func GetSpriteIDByName(name string) SpriteID {
 	}
 	return SpriteID(id)
 }
+
+func GetSpriteByID(id SpriteID) Sprite {
+	return sprites[id]
+}

--- a/world/tiletypes.go
+++ b/world/tiletypes.go
@@ -20,8 +20,10 @@ type TileConfig struct {
 	Layer        string   `yaml:"layer"`
 	Invulnerable bool     `yaml:"invulnerable"`
 	Category     string   `yaml:"category"`
+	/*
 	Width        int32    `yaml:"width"`
 	Height       int32    `yaml:"height"`
+	*/
 }
 
 func loadIDsFromSpritenames(names []string, n int) []blobsprites.BlobSpritesID {
@@ -100,13 +102,25 @@ func LayerIDFromName(name string) LayerID {
 	return id
 }
 
+func (config *TileConfig) Dims() (int32,int32) {
+	if config.Sprite == "" { return 1,1 }
+	spriteID := render.GetSpriteIDByName(config.Sprite)
+	sprite := render.GetSpriteByID(spriteID)
+	model := sprite.Model
+
+	width := int32(model.At(0,0))
+	height := int32(model.At(1,1))
+	return width,height
+}
+
 func (config *TileConfig) TileType(name string, id TileTypeID) TileType {
+	width,height := config.Dims()
 	return TileType{
 		Name:         name,
 		Layer:        LayerIDFromName(config.Layer),
 		Placer:       config.Placer(name, id),
 		Invulnerable: config.Invulnerable,
-		Width:        config.Width, Height: config.Height,
+		Width:        width, Height: height,
 	}
 }
 


### PR DESCRIPTION
closes  #333 

![Screenshot from 2021-08-10 16-27-37](https://user-images.githubusercontent.com/8276517/128930729-bcee4fca-37bd-4237-b6f0-599707b3d559.png)

# Changes
- remove obsolete sprite YAML config options
- correct spare suit scale ( solo spritesheet )
- correct container scale ( packed spritesheet )
- load sprites with default grid scale ( 16px X 16 px = 1 X 1 )