### PR TITLE
Prevent furniture overlap

### DIFF
--- a/cxmath/rect.go
+++ b/cxmath/rect.go
@@ -50,6 +50,25 @@ func (r Rect) Cells() []Vec2i {
 	return cells
 }
 
+func (r Rect) Neighbours() []Vec2i {
+	neighbours := make([]Vec2i, 0, r.Size.X*2 + r.Size.Y*2 - 4)
+	// above/below neighbours ( including corners )
+	for x := int32(-1) ; x <= r.Size.X ; x++ {
+		neighbours = append( neighbours,
+			Vec2i { r.Origin.X + x, r.Origin.Y-1 },
+			Vec2i { r.Origin.X + x, r.Origin.Y+r.Size.Y },
+		)
+	}
+	// left/right neighbours ( excluding corners )
+	for y := int32(0) ; y < r.Size.Y ; y++ {
+		neighbours = append( neighbours,
+			Vec2i { r.Origin.X-1, r.Origin.Y+y },
+			Vec2i { r.Origin.X+r.Size.X, r.Origin.Y+y },
+		)
+	}
+	return neighbours
+}
+
 type BinaryGrid struct {
 	Width,Height int
 	Occupied []bool

--- a/cxmath/rect_test.go
+++ b/cxmath/rect_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestPackRectangles(T *testing.T) {
 	width := 5
-	packed := PackRectangles(width,[]Vec2i { 
+	packed := PackRectangles(width,[]Vec2i {
 		Vec2i{1,1}, Vec2i{2,1},          Vec2i{2,2},
 		Vec2i{3,1},
 		Vec2i{5,1},
@@ -27,6 +27,35 @@ func TestPackRectangles(T *testing.T) {
 					idx,rect, otherIdx,otherRect,
 				)
 			}
+		}
+	}
+}
+
+func containsVec2i( list []Vec2i, target Vec2i ) bool {
+	for _,candidate := range list {
+		if candidate.Eq(target) { return true }
+	}
+	return false
+}
+
+func TestRectNeighbours(T *testing.T) {
+	rect := Rect { Vec2i {2,2}, Vec2i {2,1} }
+	got := rect.Neighbours()
+	want := []Vec2i {
+		Vec2i { 1,1 }, Vec2i { 2,1 }, Vec2i { 3,1 }, Vec2i { 4,1 },
+		Vec2i { 1,3 }, Vec2i { 2,3 }, Vec2i { 3,3 }, Vec2i { 4,3 },
+		Vec2i { 1,2 },                               Vec2i { 4,2 },
+	}
+	if len(got) != len(want) {
+		T.Errorf("wrong number of neighbours")
+	}
+	for _,pos := range got {
+		if !containsVec2i( want, pos ) {
+			T.Errorf(
+				"Cannot find neighbour %v in neighbours for rect with\n"+
+				"origin=%v and size=%v",
+				pos,rect.Origin,rect.Size,
+			)
 		}
 	}
 }

--- a/cxmath/veci.go
+++ b/cxmath/veci.go
@@ -34,3 +34,7 @@ func (v1 Vec2i) Length() float32 {
 func (v1 Vec2i) Vec2() mgl32.Vec2 {
 	return mgl32.Vec2 { float32(v1.X), float32(v1.Y) }
 }
+
+func (v1 Vec2i) Eq(v2 Vec2i) bool {
+	return v1.X == v2.X && v1.Y == v2.Y
+}

--- a/item/placement-grid.go
+++ b/item/placement-grid.go
@@ -186,6 +186,18 @@ func (grid *PlacementGrid) TrySelect(camCoords mgl32.Vec2) bool {
 	return false
 }
 
+func tilesAreClear(
+		World *world.World, layerID world.LayerID,
+		xstart,ystart, xstop,ystop int,
+) bool {
+	for x := xstart ; x < xstop ; x++ {
+		for y := ystart ; y < ystop ; y++ {
+			if !World.TileIsClear(layerID, x, y) { return false }
+		}
+	}
+	return true
+}
+
 func (grid *PlacementGrid) TryPlace(info ItemUseInfo) bool {
 	if !grid.HasSelected {
 		return false
@@ -194,7 +206,12 @@ func (grid *PlacementGrid) TryPlace(info ItemUseInfo) bool {
 	x32, y32 := cxmath.RoundVec2(worldCoords)
 	x := int(x32)
 	y := int(y32)
-	if info.World.TileIsClear(x, y) {
+	tt := grid.Selected.Get() // tiletype
+	canPlace := tilesAreClear(
+		info.World, tt.Layer,
+		x,y, x+int(tt.Width), y+int(tt.Height),
+	)
+	if canPlace {
 		info.World.Planet.PlaceTileType(grid.Selected, x, y)
 		return true
 	}

--- a/world/tiletype.go
+++ b/world/tiletype.go
@@ -62,7 +62,7 @@ type TileType struct {
 }
 
 func (tt TileType) Size() cxmath.Vec2i {
-	return cxmath.Vec2i{tt.Width, tt.Height}
+	return cxmath.Vec2i{ tt.Width, tt.Height }
 }
 
 func (tt *TileType) Transform() mgl32.Mat4 {

--- a/world/world.go
+++ b/world/world.go
@@ -15,7 +15,8 @@ type World struct {
 	Planet   Planet
 }
 
-func (world World) TileIsClear(x, y int) bool {
+func (world World) TileIsClear(layerID LayerID, x, y int) bool {
+	layerTiles := world.Planet.GetLayerTiles(layerID)
 	return world.Entities.Agents.TileIsClear(x, y) &&
-		!world.Planet.TileIsSolid(x, y)
+		!world.Planet.TileExists(layerTiles, x, y)
 }


### PR DESCRIPTION
closes #312 

# Changes
- add method to detect whether a range of tiles is clear (with test)
- remove unused code
- place child tiles along with root furniture tile
- update surrounding tiles using neighbours computed from furniture