### PR TITLE
Add World Stats

### DIFF
--- a/components/agents/agent_health/agent_health.go
+++ b/components/agents/agent_health/agent_health.go
@@ -1,14 +1,16 @@
 package agent_health
 
 import (
-	"github.com/skycoin/cx-game/components/agents"
+	"github.com/skycoin/cx-game/world"
 )
 
-func UpdateAgents(agentList *agents.AgentList) {
-	//todo right now only checks if agent is dead
-	for i, agent := range agentList.Agents {
+func UpdateAgents(World *world.World) {
+	for i, agent := range World.Entities.Agents.Get() {
 		if agent.Died() {
-			agentList.DestroyAgent(i)
+			ev :=
+				world.NewMobKilledEvent(agent.AgentTypeID, World.Tick)
+			World.Stats.Log(ev)
+			World.Entities.Agents.DestroyAgent(i)
 		}
 	}
 }

--- a/components/agents/agents.go
+++ b/components/agents/agents.go
@@ -11,6 +11,7 @@ import (
 )
 
 type Agent struct {
+	AgentTypeID       constants.AgentTypeID
 	AgentId           types.AgentID
 	AgentCategory     constants.AgentCategory
 	AiHandlerID       types.AgentAiHandlerID

--- a/components/agents/types.go
+++ b/components/agents/types.go
@@ -76,6 +76,7 @@ func createSlime(opts AgentCreationOptions) *Agent {
 	animation := anim.LoadAnimationFromJSON("./assets/slime.json")
 	playback := animation.NewPlayback("Idle")
 	agent := Agent{
+		AgentTypeID:   constants.AGENT_TYPE_SLIME,
 		AgentCategory: constants.AGENT_CATEGORY_ENEMY_MOB,
 		AiHandlerID:   constants.AI_HANDLER_LEAP,
 		DrawHandlerID: constants.DRAW_HANDLER_ANIM,
@@ -97,6 +98,7 @@ func createSpiderDrill(opts AgentCreationOptions) *Agent {
 	animation := anim.LoadAnimationFromJSON("./assets/spiderDrill.json")
 	playback := animation.NewPlayback("Walk")
 	agent := Agent{
+		AgentTypeID:   constants.AGENT_TYPE_SPIDER_DRILL,
 		AgentCategory: constants.AGENT_CATEGORY_ENEMY_MOB,
 		AiHandlerID:   constants.AI_HANDLER_DRILL,
 		DrawHandlerID: constants.DRAW_HANDLER_ANIM,
@@ -117,6 +119,7 @@ func createGrassHopper(opts AgentCreationOptions) *Agent {
 	animation := anim.LoadAnimationFromJSON("./assets/grassHopper.json")
 	playback := animation.NewPlayback("Idle")
 	agent := Agent{
+		AgentTypeID:   constants.AGENT_TYPE_GRASS_HOPPER,
 		AgentCategory: constants.AGENT_CATEGORY_ENEMY_MOB,
 		AiHandlerID:   constants.AI_HANDLER_GRASSHOPPER,
 		DrawHandlerID: constants.DRAW_HANDLER_ANIM,
@@ -137,6 +140,7 @@ func createEnemySoldier(opts AgentCreationOptions) *Agent {
 	animation := anim.LoadAnimationFromJSON("./assets/enemy_soldier.json")
 	playback := animation.NewPlayback("Idle")
 	agent := Agent{
+		AgentTypeID:   constants.AGENT_TYPE_ENEMY_SOLDIER,
 		AgentCategory: constants.AGENT_CATEGORY_ENEMY_MOB,
 		AiHandlerID:   constants.AI_HANDLER_ENEMYSOLDIER,
 		DrawHandlerID: constants.DRAW_HANDLER_ANIM,
@@ -153,6 +157,7 @@ func createEnemySoldier(opts AgentCreationOptions) *Agent {
 
 func createPlayer(opts AgentCreationOptions) *Agent {
 	agent := Agent{
+		AgentTypeID:   constants.AGENT_TYPE_PLAYER,
 		AgentCategory: constants.AGENT_CATEGORY_PLAYER,
 		AiHandlerID:   constants.AI_HANDLER_PLAYER,
 		DrawHandlerID: constants.DRAW_HANDLER_PLAYER,

--- a/components/init.go
+++ b/components/init.go
@@ -24,11 +24,6 @@ var (
 )
 
 func Init(World *world.World, cam *camera.Camera, player *agents.Agent) {
-	/*
-		currentWorldState = planet.WorldState
-		currentPlanet = planet
-		currentCamera = cam
-	*/
 	currentPlayer = player
 
 	agent_health.Init()
@@ -50,13 +45,6 @@ func ChangeCamera(newCamera *camera.Camera) {
 func ChangeWorld(newWorld *world.World) {
 	currentWorld = newWorld
 }
-
-/*
-func ChangePlanet(newPlanet *world.Planet) {
-	currentPlanet = newPlanet
-	currentWorldState = newPlanet.WorldState
-}
-*/
 
 func ChangePlayer(newPlayer *agents.Agent) {
 	currentPlayer = newPlayer

--- a/components/update.go
+++ b/components/update.go
@@ -34,7 +34,7 @@ func updateTimers(agents []*agents.Agent, dt float32) {
 }
 
 func FixedUpdate() {
-	agent_health.UpdateAgents(&currentWorld.Entities.Agents)
+	agent_health.UpdateAgents(currentWorld)
 	agent_physics.UpdateAgents(currentWorld)
 	agent_ai.UpdateAgents(currentWorld, currentPlayer)
 	particle_physics.Update(currentWorld)

--- a/engine/ui/console/command.go
+++ b/engine/ui/console/command.go
@@ -69,12 +69,18 @@ func Teleport(line string, ctx CommandContext) string {
 	return output
 }
 
+func PrintWorldStats(line string, ctx CommandContext) string {
+	ctx.World.Stats.Print()
+	return ""
+}
+
 func init() {
 	commands["loadmap"] = LoadMap
 	commands["savemap"] = SaveMap
 	commands["newplanet"] = NewPlanet
 	commands["tp"] = Teleport
 	commands["help"] = Help
+	commands["printworldstats"] = PrintWorldStats
 }
 
 func processCommand(line string, ctx CommandContext) string {

--- a/game/update.go
+++ b/game/update.go
@@ -63,4 +63,6 @@ func Update(dt float32) {
 		Cam,
 	)
 
+	World.Tick++
+
 }

--- a/world/planet.go
+++ b/world/planet.go
@@ -54,7 +54,6 @@ func NewLayers(numTiles int32) Layers {
 }
 
 type Planet struct {
-	//WorldState      *WorldState
 	Width           int32
 	Height          int32
 	Layers          Layers
@@ -78,7 +77,6 @@ func newPlanetLiquidProgram() render.Program {
 
 func NewPlanet(x, y int32) *Planet {
 	planet := Planet{
-		//WorldState: NewDevWorldState(),
 		Width:         x,
 		Height:        y,
 		Layers:        NewLayers(x * y),

--- a/world/stats.go
+++ b/world/stats.go
@@ -1,0 +1,62 @@
+package world
+
+import (
+	"log"
+	"github.com/skycoin/cx-game/components/types"
+	"github.com/skycoin/cx-game/constants"
+)
+
+type WorldEventType int
+
+type WorldEvent struct {
+	Type WorldEventType
+	ItemTypeID types.ItemTypeID
+	AgentTypeID constants.AgentTypeID
+	Tick int
+}
+
+// TODO pass in current world tick
+func NewMobKilledEvent(id constants.AgentTypeID, tick int) WorldEvent {
+	return WorldEvent {
+		AgentTypeID: id, Type: EVENT_TYPE_MOB_KILLED,
+	}
+}
+
+const (
+	EVENT_TYPE_UNDEFINED WorldEventType = iota
+	EVENT_TYPE_ITEM_CREATED
+	EVENT_TYPE_ITEM_CONSUMED
+	EVENT_TYPE_MOB_KILLED
+)
+
+type WorldStats struct {
+	ItemsCreated map[types.ItemTypeID]int
+	ItemsConsumed map[types.ItemTypeID]int
+	MobsKilled map[constants.AgentTypeID]int
+	EventLog []WorldEvent
+}
+
+func NewWorldStats() WorldStats {
+	return WorldStats {
+		ItemsCreated: make(map[types.ItemTypeID]int),
+		ItemsConsumed: make(map[types.ItemTypeID]int),
+		MobsKilled: make(map[constants.AgentTypeID]int),
+	}
+}
+
+func (stats *WorldStats) Log(ev WorldEvent) {
+	stats.EventLog = append(stats.EventLog, ev)
+	if ev.Type == EVENT_TYPE_ITEM_CREATED {
+		stats.ItemsCreated[ev.ItemTypeID]++
+	}
+	if ev.Type == EVENT_TYPE_ITEM_CONSUMED {
+		stats.ItemsConsumed[ev.ItemTypeID]++
+	}
+	if ev.Type == EVENT_TYPE_MOB_KILLED {
+		stats.MobsKilled[ev.AgentTypeID]++
+	}
+}
+
+func (stats *WorldStats) Print() {
+	log.Printf("%+v", stats)
+}

--- a/world/world.go
+++ b/world/world.go
@@ -11,8 +11,10 @@ type Entities struct {
 }
 
 type World struct {
+	Tick int
 	Entities Entities
 	Planet   Planet
+	Stats    WorldStats
 }
 
 func (world World) TileIsClear(layerID LayerID, x, y int) bool {

--- a/world/worldgen/worldgen.go
+++ b/world/worldgen/worldgen.go
@@ -12,5 +12,6 @@ func GenerateWorld() world.World {
 			Agents: *agents.NewAgentList(),
 		},
 		Planet: *mapgen.GeneratePlanet(),
+		Stats: world.NewWorldStats(),
 	}
 }


### PR DESCRIPTION
closes #434 

https://user-images.githubusercontent.com/8276517/132250730-fee1f2ee-0a54-40ad-b487-a4913c03f5fc.mp4



Note that since crafting/ammo systems are not present,
the "item created" and "item consumed" events have not been connected
to any player action yet.

# Changes
- track agent type IDs
- log event upon agent death
- add command for printing world stats
- add world stats
- remove outdated references to WorldState