### PR TITLE
Pipe connect via mouse drag

### DIFF
--- a/3.go
+++ b/3.go
@@ -1,9 +1,0 @@
-package main
-
-import "fmt"
-
-func main() {
-	tt := uint8(0)
-
-	fmt.Println(tt - 1)
-}

--- a/cxmath/cxmath.go
+++ b/cxmath/cxmath.go
@@ -96,3 +96,8 @@ func ClampF(x, min,max float32) float32 {
 func DegToRad(x float32) float32 {
 	return x*math.Pi/180
 }
+
+func TileAt(pos mgl32.Vec2) Vec2i {
+	x,y := RoundVec2(pos)
+	return Vec2i { x,y }
+}

--- a/item/item.go
+++ b/item/item.go
@@ -1,6 +1,7 @@
 package item
 
 import (
+	"github.com/go-gl/glfw/v3.3/glfw"
 	"github.com/go-gl/mathgl/mgl32"
 
 	"github.com/skycoin/cx-game/components/agents"
@@ -23,6 +24,8 @@ type ItemType struct {
 	Category Category
 
 	Use func(ItemUseInfo)
+	OnDrag func(ItemUseInfo, mgl32.Vec2, glfw.MouseButton)
+	MouseDownRight func(ItemUseInfo) bool
 }
 
 //type ItemTypeID uint32
@@ -68,8 +71,10 @@ var nextItemTypeID = ItemTypeID(1)
 func NewItemType(SpriteID render.SpriteID) ItemType {
 	return ItemType{
 		SpriteID: SpriteID,
-		Name:     "untitled",
+		Name:     "untitled-item",
 		Use:      func(ItemUseInfo) {},
+		OnDrag:     func(ItemUseInfo,mgl32.Vec2, glfw.MouseButton) {},
+		MouseDownRight:      func(ItemUseInfo) bool {return false},
 	}
 }
 

--- a/item/pipetool.go
+++ b/item/pipetool.go
@@ -1,0 +1,101 @@
+package item
+
+// TODO where to store state about previous mouse position
+
+import (
+	"github.com/go-gl/glfw/v3.3/glfw"
+	"github.com/go-gl/mathgl/mgl32"
+
+	"github.com/skycoin/cx-game/render"
+	"github.com/skycoin/cx-game/cxmath"
+	"github.com/skycoin/cx-game/world"
+)
+
+func pipetoolMouseDownRight(info ItemUseInfo) bool {
+	// always consume
+	return true
+}
+
+func pipetoolMouseDown(info ItemUseInfo) {
+	didSelect := info.Inventory.PlacementGrid.TrySelect(info.CamCoords())
+	if didSelect {
+		return
+	}
+	didPlace := info.Inventory.PlacementGrid.TryPlaceNoConnect(info)
+	_ = didPlace
+}
+
+func pipetoolMouseDrag(
+		info ItemUseInfo, prevMousePos mgl32.Vec2, b glfw.MouseButton,
+) {
+	currMousePos := info.WorldCoords()
+
+	prevMouseTile := cxmath.TileAt(prevMousePos)
+	currMouseTile := cxmath.TileAt(currMousePos)
+
+	// place new tile
+	didPlace := false
+	if b == glfw.MouseButtonLeft {
+		didPlace = info.Inventory.PlacementGrid.TryPlaceNoConnect(info)
+	}
+
+	planet := &info.World.Planet
+	pipeLayerTiles := planet.GetLayerTiles(world.PipeLayer)
+	prevTileIdx :=
+		planet.GetTileIndex(int(prevMouseTile.X), int(prevMouseTile.Y))
+	currTileIdx :=
+		planet.GetTileIndex(int(currMouseTile.X), int(currMouseTile.Y))
+
+	prevTile := &pipeLayerTiles[prevTileIdx]
+	currTile := &pipeLayerTiles[currTileIdx]
+
+	if didPlace { currTile.Connections = world.Connections{} }
+
+	// abort if either involved tiles are empty
+	if currTile.TileCategory == world.TileCategoryNone { return }
+	if prevTile.TileCategory == world.TileCategoryNone { return }
+	// don't try to connect tile to itself
+	if currMouseTile == prevMouseTile { return }
+
+	// connect prev tile to new tile
+
+	disp := currMouseTile.Sub(prevMouseTile)
+	prevNewConnections, currNewConnections := world.FindNewConnections(disp)
+
+	if b == glfw.MouseButtonLeft {
+		prevTile.Connections = prevTile.Connections.OR(prevNewConnections)
+		currTile.Connections = currTile.Connections.OR(currNewConnections)
+	} else { // probably mouse button right
+		prevTile.Connections =
+			prevTile.Connections.AND(prevNewConnections.NOT())
+		currTile.Connections =
+			currTile.Connections.AND(currNewConnections.NOT())
+	}
+
+	currTile.TileTypeID.Get().UpdateTile(world.TileUpdateOptions{
+		Tile:       currTile,
+		Cycling:    true,
+		Neighbours: planet.GetNeighbours(
+			pipeLayerTiles, int(currMouseTile.X), int(currMouseTile.Y),
+			currTile.TileTypeID,
+		),
+	})
+	prevTile.TileTypeID.Get().UpdateTile(world.TileUpdateOptions{
+		Tile:       prevTile,
+		Cycling:    true,
+		Neighbours: planet.GetNeighbours(
+			pipeLayerTiles, int(prevMouseTile.X), int(prevMouseTile.Y),
+			prevTile.TileTypeID,
+		),
+	})
+}
+
+func RegisterPipeToolItemType() ItemTypeID {
+	itemtype := NewItemType(render.GetSpriteIDByName("dev-pipe-place-tool"))
+	itemtype.Name = "Dev Pipe Place Tool"
+	itemtype.Category = BuildTool
+	itemtype.Use = pipetoolMouseDown
+	itemtype.OnDrag = pipetoolMouseDrag
+	itemtype.MouseDownRight = pipetoolMouseDownRight
+	return AddItemType(itemtype)
+}

--- a/item/placement-grid.go
+++ b/item/placement-grid.go
@@ -243,6 +243,28 @@ func (grid *PlacementGrid) TryPlace(info ItemUseInfo) bool {
 	return false
 }
 
+func (grid *PlacementGrid) TryPlaceNoConnect(info ItemUseInfo) bool {
+	if !grid.HasSelected || grid.Selected == 0 {
+		return false
+	}
+	worldCoords := info.WorldCoords()
+	x32, y32 := cxmath.RoundVec2(worldCoords)
+	x := int(x32)
+	y := int(y32)
+
+	tt := grid.Selected.Get()
+	canPlace := tilesAreClear(
+		info.World, tt.Layer,
+		x,y,
+		x+int(tt.Width), y+int(tt.Height),
+	)
+	if canPlace {
+		info.World.Planet.PlaceTileTypeNoConnect(grid.Selected, x, y)
+		return true
+	}
+	return false
+}
+
 func (grid *PlacementGrid) UpdatePreview(
 		World *world.World, screenX, screenY float32, Cam *camera.Camera,
 ) {

--- a/item/tool.go
+++ b/item/tool.go
@@ -1,6 +1,9 @@
 package item
 
 import (
+	"github.com/go-gl/glfw/v3.3/glfw"
+	"github.com/go-gl/mathgl/mgl32"
+
 	"github.com/skycoin/cx-game/components/agents"
 	"github.com/skycoin/cx-game/cxmath"
 	"github.com/skycoin/cx-game/engine/ui"
@@ -8,11 +11,16 @@ import (
 	"github.com/skycoin/cx-game/world"
 )
 
+func dragBuildTool(info ItemUseInfo, lastPos mgl32.Vec2, b glfw.MouseButton) {
+	UseBuildTool(info)
+}
+
 func RegisterFurnitureToolItemType() ItemTypeID {
 	itemtype := NewItemType(render.GetSpriteIDByName("dev-furniture-tool-2"))
 	itemtype.Name = "Dev Furniture Tool"
 	itemtype.Category = BuildTool
 	itemtype.Use = UseBuildTool
+	itemtype.OnDrag = dragBuildTool
 	return AddItemType(itemtype)
 }
 
@@ -21,6 +29,7 @@ func RegisterTileToolItemType() ItemTypeID {
 	itemtype.Name = "Dev Tile Tool"
 	itemtype.Category = BuildTool
 	itemtype.Use = UseBuildTool
+	itemtype.OnDrag = dragBuildTool
 	return AddItemType(itemtype)
 }
 
@@ -29,14 +38,7 @@ func RegisterBgToolItemType() ItemTypeID {
 	itemtype.Name = "Dev Background Tile Tool"
 	itemtype.Category = BuildTool
 	itemtype.Use = UseBuildTool
-	return AddItemType(itemtype)
-}
-
-func RegisterPipeToolItemType() ItemTypeID {
-	itemtype := NewItemType(render.GetSpriteIDByName("dev-pipe-place-tool"))
-	itemtype.Name = "Dev Pipe Place Tool"
-	itemtype.Category = BuildTool
-	itemtype.Use = UseBuildTool
+	itemtype.OnDrag = dragBuildTool
 	return AddItemType(itemtype)
 }
 
@@ -61,6 +63,7 @@ func RegisterDevDestroyTool() ItemTypeID {
 	itemtype.Use = UseDevDestroyTool
 	return AddItemType(itemtype)
 }
+
 func UseBuildTool(info ItemUseInfo) {
 	didSelect := info.Inventory.PlacementGrid.TrySelect(info.CamCoords())
 	if didSelect {

--- a/world/connections.go
+++ b/world/connections.go
@@ -2,6 +2,7 @@ package world
 
 import (
 	"github.com/skycoin/cx-game/world/tiling"
+	"github.com/skycoin/cx-game/cxmath"
 )
 
 type Connections struct { Up, Left, Right, Down bool }
@@ -86,4 +87,46 @@ func (c Connections) Next(valid Connections) Connections {
 		i = (i+1) % 16
 	}
 	return Connections{} // unreachable anyway
+}
+
+func FindNewConnections(disp cxmath.Vec2i) (Connections,Connections) {
+	if disp.X == 0 && disp.Y == 0 { return Connections{},Connections{} }
+	if disp.X == 0 {
+		if disp.Y > 0 {
+			return Connections { Up: true}, Connections { Down: true }
+		} else {
+			return Connections { Down: true}, Connections { Up: true }
+		}
+	} else {
+		if disp.X > 0 {
+			return Connections { Right: true}, Connections { Left: true }
+		} else {
+			return Connections { Left: true}, Connections { Right: true }
+		}
+	}
+	return Connections{},Connections{}
+}
+
+func (x Connections) OR(y Connections) Connections {
+	return Connections {
+		Up: x.Up || y.Up,
+		Down: x.Down || y.Down,
+		Left: x.Left || y.Left,
+		Right: x.Right || y.Right,
+	}
+}
+
+func (x Connections) AND(y Connections) Connections {
+	return Connections {
+		Up: x.Up && y.Up,
+		Down: x.Down && y.Down,
+		Left: x.Left && y.Left,
+		Right: x.Right && y.Right,
+	}
+}
+
+func (x Connections) NOT() Connections {
+	return Connections {
+		Up: !x.Up, Down: !x.Down, Left: !x.Left, Right: !x.Right,
+	}
 }

--- a/world/planet.go
+++ b/world/planet.go
@@ -165,7 +165,7 @@ func (planet *Planet) GetAllTilesUnique() []Tile {
 	return tiles
 }
 
-func (planet *Planet) PlaceTileType(tileTypeID TileTypeID, x, y int) {
+func (planet *Planet) PlaceTileTypeNoConnect(tileTypeID TileTypeID, x,y int) {
 	tileType, ok := GetTileTypeByID(tileTypeID)
 	if !ok {
 		log.Fatalf("cannot find tile type for id [%v]", tileTypeID)
@@ -177,14 +177,11 @@ func (planet *Planet) PlaceTileType(tileTypeID TileTypeID, x, y int) {
 	}
 	tilesInLayer[rootTileIdx] =
 		tileType.CreateTile(TileCreationOptions{
-			Neighbours: planet.GetNeighbours(tilesInLayer, x, y, tileTypeID),
+			//Neighbours: planet.GetNeighbours(tilesInLayer, x, y, tileTypeID),
 		})
 	rect := cxmath.Rect{
 		cxmath.Vec2i{int32(x), int32(y)},
 		tileType.Size(),
-	}
-	for _, neighbour := range rect.Neighbours() {
-		planet.updateTile(tilesInLayer, int(neighbour.X), int(neighbour.Y))
 	}
 
 	// place child tiles (non-root) to prevent overlap
@@ -209,6 +206,23 @@ func (planet *Planet) PlaceTileType(tileTypeID TileTypeID, x, y int) {
 	if tileType.Layer == TopLayer {
 		planet.LightAddBlock(x, y)
 	}
+}
+
+func (planet *Planet) PlaceTileType(tileTypeID TileTypeID, x, y int) {
+	tileType, ok := GetTileTypeByID(tileTypeID)
+	if !ok {
+		log.Fatalf("cannot find tile type for id [%v]", tileTypeID)
+	}
+	tilesInLayer := planet.GetLayerTiles(tileType.Layer)
+	planet.PlaceTileTypeNoConnect(tileTypeID, x,y)
+	rect := cxmath.Rect{
+		cxmath.Vec2i{int32(x), int32(y)},
+		tileType.Size(),
+	}
+	for _, neighbour := range rect.Neighbours() {
+		planet.updateTile(tilesInLayer, int(neighbour.X), int(neighbour.Y))
+	}
+	planet.updateTile(tilesInLayer, x,y)
 }
 
 // cycle the pipe connection state at (x,y) to the next valid state.


### PR DESCRIPTION
closes #453 

https://user-images.githubusercontent.com/8276517/133505811-d89a649e-feb8-4702-8546-a31f65f6fabc.mp4

Changes:
- right mouse does not place pipes
- right mouse disconnects pipes
- pass mouse button being dragged to itemtype
- override right click behaviour for pipe tool
- pipes connect manually
- disable pipe connections by default
- detect mouse tile move
- pass in previous mouse world positoin to OnDrag()
- generalize item mouse drag logic
- add OnDrag() function member to ItemType
- remove unused file