### PR TITLE
Automatic World Outline

### DIFF
--- a/assets/shader/outline.frag
+++ b/assets/shader/outline.frag
@@ -1,0 +1,16 @@
+in vec2 tCoord;
+out vec4 frag_colour;
+uniform sampler2D tex;
+uniform vec2 texelSize;
+uniform vec4 borderColor;
+void main() {
+	vec4 above = texture(tex,vec2(tCoord.x,tCoord.y-texelSize.y));
+	vec4 below = texture(tex,vec2(tCoord.x,tCoord.y+texelSize.y));
+	vec4 left = texture(tex,vec2(tCoord.x-texelSize.x,tCoord.y));
+	vec4 right = texture(tex,vec2(tCoord.x+texelSize.x,tCoord.y));
+	vec4 here = texture(tex,tCoord);
+
+	float others = above.a+below.a+left.a+right.a;
+	bool isBorder = here.a < 0.1 && others > 0;
+	frag_colour = isBorder ? borderColor : here;
+}

--- a/assets/shader/outline.vert
+++ b/assets/shader/outline.vert
@@ -1,0 +1,8 @@
+layout (location=0) in vec3 position;
+layout (location=1) in vec2 texCoord;
+out vec2 tCoord;
+uniform mat4 projection;
+void main() {
+	gl_Position = projection * vec4(position,1);
+	tCoord = vec2(texCoord.x,texCoord.y);
+}

--- a/constants/render.go
+++ b/constants/render.go
@@ -25,5 +25,5 @@ const (
 )
 
 var (
-	OUTLINE_BORDER_COLOR = mgl32.Vec4{1,0,0,1}
+	OUTLINE_BORDER_COLOR = mgl32.Vec4{0,0,0,1}
 )

--- a/constants/render.go
+++ b/constants/render.go
@@ -1,9 +1,15 @@
 package constants
 
+import (
+	"github.com/go-gl/mathgl/mgl32"
+)
+
 const (
-	DRAW_SPRITE_BATCH_SIZE int32 = 100
-	DRAW_COLOR_BATCH_SIZE  int32 = 100
-	PIXELS_PER_TILE        int   = 32
+	DRAW_SPRITE_BATCH_SIZE  int32 = 100
+	DRAW_COLOR_BATCH_SIZE   int32 = 100
+	PIXELS_PER_TILE         int   = 32
+	VIRTUAL_VIEWPORT_WIDTH  int32   = 1440
+	VIRTUAL_VIEWPORT_HEIGHT int32   = 900
 )
 
 const (
@@ -16,4 +22,8 @@ const (
 	AGENT_Z      float32 = -5
 	PLAYER_Z     float32 = -3
 	HUD_Z        float32 = 0
+)
+
+var (
+	OUTLINE_BORDER_COLOR = mgl32.Vec4{1,0,0,1}
 )

--- a/game/draw.go
+++ b/game/draw.go
@@ -24,6 +24,12 @@ func Draw() {
 	gl.ClearColor(7.0/255.0, 8.0/255.0, 25.0/255.0, 1.0)
 	gl.Clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT)
 
+	render.FRAMEBUFFER_PLANET.Bind(gl.FRAMEBUFFER)
+	gl.ClearColor(0,0,0,0)
+	gl.Clear(gl.COLOR_BUFFER_BIT|gl.DEPTH_BUFFER_BIT)
+
+	render.FRAMEBUFFER_SCREEN.Bind(gl.FRAMEBUFFER)
+
 	baseCtx := win.DefaultRenderContext()
 	render.SetCameraTransform(Cam.GetTransform())
 	render.SetWorldWidth(float32(World.Planet.Width))

--- a/game/init.go
+++ b/game/init.go
@@ -31,11 +31,6 @@ func init() {
 	runtime.LockOSThread()
 }
 
-const (
-	INITIAL_WINDOW_WIDTH  = 1440
-	INITIAL_WINDOW_HEIGHT = 900
-)
-
 var (
 	Console console.Console
 	Cam     *camera.Camera
@@ -54,7 +49,9 @@ var (
 )
 
 func Init() {
-	win = render.NewWindow(INITIAL_WINDOW_WIDTH, INITIAL_WINDOW_HEIGHT, true)
+	vvw := int(constants.VIRTUAL_VIEWPORT_WIDTH)
+	vvh := int(constants.VIRTUAL_VIEWPORT_HEIGHT)
+	win = render.NewWindow(vvw,vvh,true)
 	win.SetCallbacks()
 	// defer glfw.Terminate()
 

--- a/item/inventory.go
+++ b/item/inventory.go
@@ -149,29 +149,30 @@ func getBorderColor(isSelected bool) mgl32.Vec4 {
 func (inventory Inventory) DrawSlot(
 	slot InventorySlot, ctx render.Context, isSelected bool,
 ) {
-
+	transform := ctx.World.Mul4(mgl32.Translate3D(0,0,0.2))
 	// draw border
-	render.DrawColorQuad(ctx.World, getBorderColor(isSelected))
+	render.DrawColorQuad(transform, getBorderColor(isSelected))
 	// draw bg on top of border
-	bgCtx := ctx.
-		PushLocal(mgl32.Translate3D(0, 0, 0.1)).
-		PushLocal(cxmath.Scale(1 - borderSize))
-	// bgCtx = ctx
-	render.DrawColorQuad(bgCtx.World, bgColor)
+	bgTransform := transform.
+		Mul4(mgl32.Translate3D(0, 0, 0.1)).
+		Mul4(cxmath.Scale(1 - borderSize))
+	render.DrawColorQuad(bgTransform, bgColor)
 	// draw item on top of bg
-	itemCtx := ctx.
-		PushLocal(cxmath.Scale(itemSize))
+	itemTransform := bgTransform.Mul4(cxmath.Scale(itemSize)).Mul4(
+		mgl32.Translate3D(0,0,0.1))
 
 	if slot.Quantity > 0 {
 		spriteId := itemTypes[slot.ItemTypeID].SpriteID
 		render.DrawUISprite(
-			itemCtx.World.Mul4(
+			itemTransform.Mul4(
 				mgl32.Translate3D(0, 0, 0.2)), spriteId,
 			render.NewSpriteDrawOptions())
 
-		textCtx := itemCtx.PushLocal(
-			mgl32.Translate3D(0.5, -0.05, 0.3).
-				Mul4(cxmath.Scale(0.6)))
+		textTransform := itemTransform.
+			Mul4(mgl32.Translate3D(0.5, -0.05, 0.3)).
+			Mul4(cxmath.Scale(0.6))
+		textCtx := render.Context {
+			World: textTransform, Projection: ctx.Projection }
 		ui.DrawStringRightAligned(
 			strconv.Itoa(int(slot.Quantity)),
 			mgl32.Vec4{1, 1, 1, 1},

--- a/render/framebuffer.go
+++ b/render/framebuffer.go
@@ -1,0 +1,108 @@
+package render
+
+import (
+	"log"
+	"github.com/go-gl/gl/v4.1-core/gl"
+	"github.com/skycoin/cx-game/constants"
+)
+
+type Framebuffer uint32
+
+func (f Framebuffer) Gl() uint32 { return uint32(f) }
+func (f Framebuffer) Bind(target uint32) {
+	gl.BindFramebuffer(target, f.Gl())
+}
+func (f Framebuffer) Unbind() {
+	gl.BindFramebuffer(gl.FRAMEBUFFER, 0)
+}
+func (f Framebuffer) SetTexture2D(texture uint32) {
+	gl.FramebufferTexture2D(
+		gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D,
+		texture, 0,
+	)
+}
+
+func (f Framebuffer) Attach(attachment uint32, texture uint32) {
+	gl.FramebufferTexture2D(
+		gl.FRAMEBUFFER, attachment, gl.TEXTURE_2D, texture, 0,
+	)
+}
+
+func GenFramebuffer() Framebuffer {
+	var fbo uint32
+	gl.GenFramebuffers(1, &fbo)
+	return Framebuffer(fbo)
+}
+
+var (
+	FRAMEBUFFER_SCREEN = Framebuffer(0)
+	FRAMEBUFFER_PLANET Framebuffer
+	RENDERTEXTURE_PLANET uint32
+)
+
+func InitPlanetFrameBuffer() {
+	fb := GenFramebuffer()
+	fb.Bind(gl.FRAMEBUFFER)
+	defer fb.Unbind()
+
+	var tex uint32
+	gl.GenTextures(1, &tex)
+	gl.BindTexture(gl.TEXTURE_2D, tex)
+
+	gl.TexImage2D(
+		gl.TEXTURE_2D, 0, gl.RGBA,
+		constants.VIRTUAL_VIEWPORT_WIDTH, constants.VIRTUAL_VIEWPORT_HEIGHT,
+		0, gl.RGBA, gl.UNSIGNED_BYTE, nil,
+	)
+
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+
+	var depth uint32
+	gl.GenTextures(1, &depth)
+	gl.BindTexture(gl.TEXTURE_2D, depth)
+
+	gl.TexImage2D(
+	  gl.TEXTURE_2D, 0, gl.DEPTH24_STENCIL8,
+	  constants.VIRTUAL_VIEWPORT_WIDTH, constants.VIRTUAL_VIEWPORT_HEIGHT, 0,
+	  gl.DEPTH_STENCIL, gl.UNSIGNED_INT_24_8, nil,
+	)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+
+	// unbind texture such that we can attach it to the framebuffer
+	gl.BindTexture(gl.TEXTURE_2D,0)
+	fb.SetTexture2D(tex)
+	fb.Attach(gl.DEPTH_STENCIL_ATTACHMENT, depth)
+
+	FRAMEBUFFER_PLANET = fb
+	RENDERTEXTURE_PLANET = tex
+}
+
+func BlitFramebuffer(
+		readFramebuffer, drawFramebuffer Framebuffer,
+		srcX0, srcY0, srcX1, srcY1 int32,
+		dstX0, dstY0, dstX1, dstY1 int32,
+		mask uint32, filter uint32,
+) {
+	checkError("before bind read")
+	readFramebuffer.Bind(gl.READ_FRAMEBUFFER)
+	checkError("after bind read")
+	drawFramebuffer.Bind(gl.DRAW_FRAMEBUFFER)
+	checkError("after bind draw")
+
+	gl.BlitFramebuffer(
+		srcX0,srcY0,srcX1,srcY1,
+		dstX0,dstY0,dstX1,dstY1,
+		mask, filter,
+	)
+
+	checkError("after blit")
+}
+
+func checkError(prefix string) {
+	errorCode := gl.GetError()
+	if errorCode != gl.NO_ERROR {
+		log.Printf("%v: got GL error code [%v]", prefix,errorCode)
+	}
+}

--- a/render/gltex.go
+++ b/render/gltex.go
@@ -22,7 +22,7 @@ func (t Texture) Unbind() {
 }
 
 func (t Texture) SetTextureFiltering(minFilter, magFilter int32) {
-	//assume we already bind the texture
+	// assume we already bind the texture
 	gl.TexParameteri(t.Target, gl.TEXTURE_MIN_FILTER, minFilter)
 	gl.TexParameteri(t.Target, gl.TEXTURE_MAG_FILTER, magFilter)
 }

--- a/render/init.go
+++ b/render/init.go
@@ -1,0 +1,9 @@
+package render
+
+func Init() {
+	initSprite()
+	initColor()
+
+	InitPlanetFrameBuffer()
+	InitOutlineProgram()
+}

--- a/render/outline-program.go
+++ b/render/outline-program.go
@@ -1,0 +1,8 @@
+package render
+
+var outlineProgram Program
+
+func InitOutlineProgram() {
+	outlineProgram = CompileProgram(
+		"./assets/shader/outline.vert", "./assets/shader/outline.frag" )
+}

--- a/render/quad.go
+++ b/render/quad.go
@@ -5,15 +5,17 @@ import (
 )
 
 var QuadVao uint32
+var Quad2Vao uint32
 const vertsPerQuad int32 = 6
 
 func InitQuadVao() {
-	QuadVao = MakeQuadVao()
+	QuadVao = MakeQuadVao(quadVertexAttributes)
+	Quad2Vao = MakeQuadVao(quad2VertexAttributes)
 }
 
 // x,y,z,u,v
 var quadVertexAttributes = []float32{
-	0.5, 0.5, 0, 1, 0,
+	0.5, 0.5,  0, 1, 0,
 	0.5, -0.5, 0, 1, 1,
 	-0.5, 0.5, 0, 0, 0,
 
@@ -22,8 +24,19 @@ var quadVertexAttributes = []float32{
 	-0.5, 0.5, 0, 0, 0,
 }
 
+// x,y,z,u,v
+var quad2VertexAttributes = []float32{
+	0,0, 0, 0,0,
+	0,1, 0, 0,1,
+	1,0, 0, 1,0,
 
-func MakeQuadVao() uint32 {
+	0,1, 0, 0,1,
+	1,1, 0, 1,1,
+	1,0, 0, 1,0,
+}
+
+
+func MakeQuadVao(vertexAttributes []float32) uint32 {
 	var vbo uint32
 	gl.GenBuffers(1, &vbo)
 
@@ -34,8 +47,8 @@ func MakeQuadVao() uint32 {
 	gl.BindBuffer(gl.ARRAY_BUFFER, vbo)
 	gl.BufferData(
 		gl.ARRAY_BUFFER,
-		4*len(quadVertexAttributes),
-		gl.Ptr(quadVertexAttributes),
+		4*len(vertexAttributes),
+		gl.Ptr(vertexAttributes),
 		gl.STATIC_DRAW,
 	)
 	gl.VertexAttribPointer(0, 3, gl.FLOAT, false, 5*4, gl.PtrOffset(0))

--- a/render/sprite.go
+++ b/render/sprite.go
@@ -47,7 +47,6 @@ func initSprite() {
 	spriteProgram = &spriteProgram1
 }
 
-func Init() { initSprite(); initColor() }
 
 type Sprite struct {
 	Name      string

--- a/render/viewport.go
+++ b/render/viewport.go
@@ -18,7 +18,10 @@ type Viewport struct {
 	X,Y,Width,Height int32
 }
 
+var currentViewport Viewport
+
 func (v Viewport) Use() {
+	currentViewport = v
 	gl.Viewport(v.X, v.Y, v.Width, v.Height)
 }
 

--- a/world/draw.go
+++ b/world/draw.go
@@ -75,10 +75,10 @@ func (planet *Planet) DrawHemisphere(
 
 		transform := positionedTile.Transform().
 			Mul4(mgl32.Translate3D(0, 0, z))
-		render.DrawWorldSprite(
-			transform, positionedTile.Tile.SpriteID,
-			render.NewSpriteDrawOptions(),
-		)
+		drawOpts := render.NewSpriteDrawOptions()
+		drawOpts.Outline = true
+		render.
+			DrawWorldSprite(transform, positionedTile.Tile.SpriteID,drawOpts)
 	}
 }
 


### PR DESCRIPTION
closes #442 

![outline](https://user-images.githubusercontent.com/8276517/135508599-3705ef73-9ca0-48b6-a90a-f733298da51e.png)


# Changes
- outline world
- detect border with postprocessing shader program
- adjust projection for postprocessing
- add outline.vert and outline.frag
- clear planet framebuffer at beginning of draw
- setup intermediary framebuffer for planet