### PR TITLE
Electric Lights

### DIFF
--- a/assets/luis/tiled files/Objects.tsx
+++ b/assets/luis/tiled files/Objects.tsx
@@ -83,9 +83,17 @@
   <image width="16" height="16" source="../furniture/decorations/surveillanceCamera.png"/>
  </tile>
  <tile id="26">
+  <properties>
+   <property name="cxtile" value="light1"/>
+   <property name="powered" type="bool" value="false"/>
+  </properties>
   <image width="16" height="16" source="../lights/light_1_off.png"/>
  </tile>
  <tile id="27">
+  <properties>
+   <property name="cxtile" value="light1"/>
+   <property name="powered" type="bool" value="true"/>
+  </properties>
   <image width="16" height="16" source="../lights/light_1_on.png"/>
  </tile>
  <tile id="28">

--- a/engine/ui/console/command.go
+++ b/engine/ui/console/command.go
@@ -57,7 +57,7 @@ func Teleport(line string, ctx CommandContext) string {
 		ctx.Player.Transform.Pos.X,
 		ctx.Player.Transform.Pos.Y,
 	)
-	if len(words) > 1 {
+	if len(words) > 2 {
 		x,err := strconv.ParseFloat(words[1],32)
 		if err!=nil { log.Fatalf("Teleport() [x]: %v",err) }
 		y,err := strconv.ParseFloat(words[2], 32)
@@ -81,6 +81,7 @@ func init() {
 	commands["tp"] = Teleport
 	commands["help"] = Help
 	commands["printworldstats"] = PrintWorldStats
+	commands["power"] = Power
 }
 
 func processCommand(line string, ctx CommandContext) string {
@@ -88,8 +89,7 @@ func processCommand(line string, ctx CommandContext) string {
 	commandName := words[0]
 	command, ok := commands[commandName]
 	if !ok {
-		log.Printf("unrecognized command [%s]", commandName)
-		return ""
+		return fmt.Sprintf("unrecognized command [%s]", commandName)
 	}
 	return command(line, ctx)
 }

--- a/engine/ui/console/power.go
+++ b/engine/ui/console/power.go
@@ -1,0 +1,34 @@
+package console
+
+import (
+	"fmt"
+	"errors"
+	"strings"
+	"strconv"
+)
+
+func onOffToBool(onOff string) (bool,error) {
+	if onOff == "on" {
+		return true,nil
+	} else if onOff == "off" {
+		return false, nil
+	}
+	return false, errors.New("onOff is neither on nor off")
+}
+
+func Power(line string, ctx CommandContext) string {
+	words := strings.Split(line," ")
+	if len(words) < 4 {
+		return "need 4 args"
+	}
+	x,err := strconv.Atoi(words[1])
+	if err!=nil { return "parse error [x]" }
+	y,err := strconv.Atoi(words[2])
+	if err!=nil { return "parse error [y]" }
+	onOff := words[3]
+	isOn ,err := onOffToBool(onOff)
+	if err!=nil { return err.Error() }
+
+	ctx.World.Planet.TogglePower(x,y,isOn)
+	return fmt.Sprintf("powered %d,%d %s", x,y, onOff)
+}

--- a/game/glfw_callbacks.go
+++ b/game/glfw_callbacks.go
@@ -75,11 +75,11 @@ func mousePressCallback(
 
 		worldX, worldY := cxmath.RoundVec2(worldCoords.Vec2())
 
-		tile := World.Planet.GetTile(int(worldX), int(worldY), world.TopLayer)
+		tile,_ := World.Planet.GetTile(int(worldX), int(worldY), world.TopLayer)
 		if tile.Name == "" {
-			tile = World.Planet.GetTile(int(worldX), int(worldY), world.MidLayer)
+			tile,_ = World.Planet.GetTile(int(worldX), int(worldY), world.MidLayer)
 			if tile.Name == "" {
-				tile = World.Planet.GetTile(int(worldX), int(worldY), world.BgLayer)
+				tile,_ = World.Planet.GetTile(int(worldX), int(worldY), world.BgLayer)
 				if tile.Name != "" {
 					item.SelectedLayer = world.BgLayer
 				}
@@ -131,9 +131,9 @@ func cursorPosCallback(w *glfw.Window, xpos, ypos float64) {
 		if idx == -1 {
 			return
 		}
-		tile := World.Planet.GetTile(int(worldX), int(worldY), world.TopLayer)
+		tile,_ := World.Planet.GetTile(int(worldX), int(worldY), world.TopLayer)
 		if tile.Name == "" {
-			tile = World.Planet.GetTile(int(worldX), int(worldY), world.MidLayer)
+			tile,_ = World.Planet.GetTile(int(worldX), int(worldY), world.MidLayer)
 		}
 
 		tileText = fmt.Sprintf("Tile: %v,  EnvLight: %v,   SkyLight: %v\n",

--- a/game/init.go
+++ b/game/init.go
@@ -97,13 +97,7 @@ func Init() {
 	worldTiles := World.Planet.GetAllTilesUnique()
 	log.Printf("Found [%v] unique tiles in the world", len(worldTiles))
 
-	spawnX := int(20)
-	Cam.SetCameraPosition(float32(spawnX), 5)
-
-	spawnPos := cxmath.Vec2{
-		float32(spawnX),
-		float32(World.Planet.GetHeight(spawnX) + 10),
-	}
+	spawnPos := cxmath.Vec2{ 80, 109 } // start pos for moon bunker map
 
 	World.Entities.Agents.Spawn(
 		constants.AGENT_TYPE_SLIME, agents.AgentCreationOptions{

--- a/item/item.go
+++ b/item/item.go
@@ -109,7 +109,8 @@ func GetItemTypeIdForTileTypeID(id world.TileTypeID) ItemTypeID {
 		y := int(worldCoords.Y() + 0.5)
 		if !info.World.Planet.TileIsSolid(x, y) {
 			info.Slot.Quantity--
-			info.World.Planet.PlaceTileType(id, x, y)
+			opts := world.NewTileCreationOptions()
+			info.World.Planet.PlaceTileType(id, x, y, opts)
 		}
 	}
 	itemTypeID = AddItemType(itemType)

--- a/item/placement-grid.go
+++ b/item/placement-grid.go
@@ -245,7 +245,8 @@ func (grid *PlacementGrid) TryPlace(info ItemUseInfo) bool {
 	x := int(x32)
 	y := int(y32)
 	if grid.canPlace {
-		info.World.Planet.PlaceTileType(grid.Selected, x, y)
+		opts := world.NewTileCreationOptions()
+		info.World.Planet.PlaceTileType(grid.Selected, x, y, opts)
 		return true
 	}
 	return false
@@ -267,7 +268,8 @@ func (grid *PlacementGrid) TryPlaceNoConnect(info ItemUseInfo) bool {
 		x+int(tt.Width), y+int(tt.Height),
 	)
 	if canPlace {
-		info.World.Planet.PlaceTileTypeNoConnect(grid.Selected, x, y)
+		opts := world.NewTileCreationOptions()
+		info.World.Planet.PlaceTileTypeNoConnect(grid.Selected, x, y, opts)
 		return true
 	}
 	return false

--- a/world/draw.go
+++ b/world/draw.go
@@ -2,7 +2,6 @@ package world
 
 import (
 	"github.com/go-gl/mathgl/mgl32"
-	//"github.com/go-gl/gl/v4.1-core/gl"
 
 	"github.com/skycoin/cx-game/cxmath"
 	"github.com/skycoin/cx-game/cxmath/mathi"
@@ -57,7 +56,8 @@ func (planet *Planet) DrawHemisphere(
 	for _, positionedTile := range visible {
 		z := layerID.Z()
 		transform := positionedTile.Transform().
-			Mul4(mgl32.Translate3D(0, 0, z))
+			Mul4(mgl32.Translate3D(0, 0, z)).
+			Mul4(positionedTile.Tile.FlipTransform)
 		drawOpts := render.NewSpriteDrawOptions()
 		if layerID == TopLayer {
 			drawOpts.Outline = true

--- a/world/import/interface.go
+++ b/world/import/interface.go
@@ -3,6 +3,7 @@ package worldimport
 import (
 	"log"
 	"time"
+	"path"
 
 	"github.com/skycoin/cx-game/components/agents"
 	"github.com/skycoin/cx-game/world"
@@ -17,11 +18,21 @@ func ImportWorld(tmxPath string) world.World {
 	}
 	elapsedTiledLoad := time.Since(start)
 	log.Printf("load %s took %s", tmxPath, elapsedTiledLoad)
+
+	allTiledSprites :=
+		findTiledSpritesInMapTilesets(tiledMap, path.Join(tmxPath,".."))
+	mapTiledSprites := filterTiledSpritesInMapLayers(allTiledSprites, tiledMap)
+
+	registeredTileSprites := registerTiledSprites(mapTiledSprites)
+	tileTypeIDs := registerTileTypesForTiledSprites(registeredTileSprites)
+
 	planet := world.NewPlanet(int32(tiledMap.Width), int32(tiledMap.Height))
 	for _, tiledLayer := range tiledMap.Layers {
 		layerID, foundLayerID := world.LayerIDForName(tiledLayer.Name)
 		if foundLayerID {
-			importLayer(planet, tiledLayer, tmxPath, layerID)
+			importLayer(
+				planet, tiledLayer, tmxPath, layerID, tileTypeIDs,
+			)
 		}
 	}
 	return world.World{

--- a/world/import/register.go
+++ b/world/import/register.go
@@ -1,0 +1,116 @@
+package worldimport
+
+import (
+	"fmt"
+	"image"
+	"log"
+	"path"
+
+	"github.com/go-gl/mathgl/mgl32"
+	"github.com/lafriks/go-tiled"
+
+	"github.com/go-gl/gl/v4.1-core/gl"
+	"github.com/skycoin/cx-game/engine/spriteloader"
+	"github.com/skycoin/cx-game/render"
+	"github.com/skycoin/cx-game/world"
+)
+
+func nameForTilesetTile(tilesetName string, tileID uint32) string {
+	return fmt.Sprintf("%v:%v", tilesetName, tileID)
+}
+
+func nameForLayerTile(layerTile *tiled.LayerTile) string {
+	return parseMetadataFromLayerTile(layerTile).Name
+}
+
+type TileRegistrationOptions struct {
+	TmxPath string
+	LayerID world.LayerID
+
+	Tileset     *tiled.Tileset
+	LayerTile   *tiled.LayerTile
+	TilesetTile *tiled.TilesetTile
+
+	FlipTransform mgl32.Mat3
+
+	TiledSprites TiledSprites
+}
+
+type TilesetTileImage struct {
+	Path            string
+	SpriteTransform mgl32.Mat3
+	Width           int32 // measured in tiles
+	Height          int32
+}
+
+func (t TilesetTileImage) Model() mgl32.Mat4 {
+	return mgl32.Scale3D(float32(t.Width), float32(t.Height), 1)
+}
+
+func (t TilesetTileImage) RegisterSprite(name string) render.SpriteID {
+	texture :=
+		spriteloader.LoadTextureFromFileToGPUCached(t.Path)
+	sprite := render.Sprite{
+		Name:      name,
+		Transform: t.SpriteTransform,
+		Model:     t.Model(),
+		Texture:   render.Texture{Target: gl.TEXTURE_2D, Texture: texture.Gl},
+	}
+	return render.RegisterSprite(sprite)
+}
+
+func registerTilesetTile(
+	layerTile *tiled.LayerTile, opts TileRegistrationOptions,
+) world.TileTypeID {
+	name := nameForLayerTile(layerTile)
+	pathPrefix := path.Join(opts.TmxPath, "..")
+	tilesetTileImage := imageForTilesetTile(
+		opts.Tileset, layerTile.ID, opts.TilesetTile, pathPrefix)
+
+	tiledSprites, ok := opts.TiledSprites[name]
+	if !ok {
+		log.Fatalf("unrecognized tile: %v", name)
+	}
+	spriteID := tiledSprites[0].Image.RegisterSprite(name)
+
+	tile := world.NewNormalTile()
+	tile.Name = name
+	tile.TileTypeID = world.NextTileTypeID()
+
+	tileType := world.TileType{
+		Name:   name,
+		Layer:  opts.LayerID,
+		Placer: world.DirectPlacer{SpriteID: spriteID, Tile: tile},
+		Width:  tilesetTileImage.Width, Height: tilesetTileImage.Height,
+	}
+
+	tileTypeID :=
+		world.RegisterTileType(name, tileType, defaltToolForLayer(opts.LayerID))
+
+	return tileTypeID
+}
+
+func imageForTilesetTile(
+	tileset *tiled.Tileset, tileID uint32, tilesetTile *tiled.TilesetTile,
+	pathPrefix string,
+) TilesetTileImage {
+	if tilesetTile != nil && tilesetTile.Image != nil {
+		tileImg := tilesetTile.Image
+		imgPath := path.Join(pathPrefix, tileImg.Source)
+		return TilesetTileImage{
+			Path:            imgPath,
+			SpriteTransform: mgl32.Ident3(),
+			Width:           int32(tileImg.Width) / 16, Height: int32(tileImg.Height) / 16,
+		}
+	} else {
+		imgPath := path.Join(pathPrefix, tileset.Image.Source)
+		spriteRect := tileset.GetTileRect(tileID)
+		tilesetDims := image.Point{tileset.Image.Width, tileset.Image.Height}
+		spriteTransform := rectTransform(spriteRect, tilesetDims)
+		return TilesetTileImage{
+			Path:            imgPath,
+			SpriteTransform: spriteTransform,
+			Width:           1, Height: 1,
+		}
+	}
+}

--- a/world/import/register_sprites.go
+++ b/world/import/register_sprites.go
@@ -1,0 +1,140 @@
+package worldimport
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/lafriks/go-tiled"
+
+	"github.com/skycoin/cx-game/render"
+	"github.com/skycoin/cx-game/world"
+)
+
+// a sprite registered from a tiled import
+type TiledSprite struct {
+	Image    TilesetTileImage
+	Metadata TiledMetadata
+}
+
+func (ts TiledSprite) Register(name string) RegisteredTiledSprite {
+	return RegisteredTiledSprite{
+		SpriteID: ts.Image.RegisterSprite(name),
+		Metadata: ts.Metadata, // just copy metadata over
+		Width:    ts.Image.Width,
+		Height:   ts.Image.Height,
+	}
+}
+
+type RegisteredTiledSprite struct {
+	SpriteID render.SpriteID
+	Width    int32
+	Height   int32
+	Metadata TiledMetadata
+}
+
+// properties on a Tiled tileset tile that are relevant to cx-game
+type TiledMetadata struct {
+	Powered OptionalBool
+	Name    string
+	LayerID world.LayerID
+}
+
+func NewTiledMetadata(name string) TiledMetadata {
+	return TiledMetadata{Name: name, LayerID: world.TopLayer}
+}
+
+type OptionalBool struct {
+	Set   bool
+	Value bool
+}
+
+type LayerTiledSpritePair struct {
+	LayerID world.LayerID
+	Sprite  TiledSprite
+}
+
+type TiledSprites map[string][]TiledSprite
+type RegisteredTiledSprites map[string][]RegisteredTiledSprite
+
+func findTiledSpritesInMapTilesets(
+	tiledMap *tiled.Map, mapDir string,
+) TiledSprites {
+	tiledSprites := TiledSprites{}
+
+	for _, tileset := range tiledMap.Tilesets {
+		log.Printf("registering sprites for tileset %v", tileset.Name)
+		registeredTileIDs := map[uint32]bool{}
+		for _, tilesetTile := range tileset.Tiles {
+			name := nameForTilesetTile(tileset.Name, tilesetTile.ID)
+			metadata := NewTiledMetadata(name)
+			metadata.ParseFrom(tilesetTile.Properties)
+			image := imageForTilesetTile(
+				tileset, tilesetTile.ID, tilesetTile, mapDir)
+			tiledSprite := TiledSprite{Image: image, Metadata: metadata}
+			tiledSprites[metadata.Name] =
+				append(tiledSprites[metadata.Name], tiledSprite)
+			registeredTileIDs[tilesetTile.ID] = true
+		}
+		if tileset.Image != nil {
+			for id := uint32(0); id < uint32(tileset.TileCount); id++ {
+				name := nameForTilesetTile(tileset.Name, id)
+				metadata := NewTiledMetadata(name)
+				isRegistered, _ := registeredTileIDs[id]
+				if !isRegistered {
+					image :=
+						imageForTilesetTile(tileset, uint32(id), nil, mapDir)
+					tiledSprite :=
+						TiledSprite{Image: image, Metadata: metadata}
+					tiledSprites[metadata.Name] =
+						append(tiledSprites[metadata.Name], tiledSprite)
+				}
+			}
+		}
+	}
+
+	return tiledSprites
+}
+
+func registerTiledSprites(tiledSprites TiledSprites) RegisteredTiledSprites {
+	registeredTiledSprites := RegisteredTiledSprites{}
+	for name, tileSprites := range tiledSprites {
+		registeredTiledSprites[name] = []RegisteredTiledSprite{}
+		for _, tileSprite := range tileSprites {
+			_, ok := world.IDFor(name)
+			if !ok {
+				registeredTiledSprites[name] = append(
+					registeredTiledSprites[name], tileSprite.Register(name) )
+			}
+		}
+	}
+	return registeredTiledSprites
+}
+
+func hasProperty(properties tiled.Properties, name string) bool {
+	for _, property := range properties {
+		if property.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (metadata *TiledMetadata) ParseFrom(properties tiled.Properties) {
+	if hasProperty(properties, "powered") {
+		metadata.Powered.Set = true
+		metadata.Powered.Value = properties.GetBool("powered")
+	}
+	if hasProperty(properties, "cxtile") {
+		metadata.Name = properties.GetString("cxtile")
+	}
+}
+
+func parseMetadataFromLayerTile(layerTile *tiled.LayerTile) TiledMetadata {
+	name := fmt.Sprintf("%v:%v", layerTile.Tileset.Name, layerTile.ID)
+	metadata := NewTiledMetadata(name)
+	tilesetTile, ok := findTilesetTileForLayerTile(layerTile)
+	if ok {
+		metadata.ParseFrom(tilesetTile.Properties)
+	}
+	return metadata
+}

--- a/world/import/world.go
+++ b/world/import/world.go
@@ -1,6 +1,10 @@
 package worldimport
 
 import (
+	"log"
+
+	"github.com/go-gl/mathgl/mgl32"
+
 	"github.com/lafriks/go-tiled"
 	"github.com/skycoin/cx-game/world"
 )
@@ -8,24 +12,58 @@ import (
 func importTile(
 	planet *world.Planet,
 	tileIndex int, layerTile *tiled.LayerTile, tmxPath string,
-	layerID world.LayerID,
+	layerID world.LayerID, tileTypeIDs map[string]world.TileTypeID,
 ) {
-	tileTypeID := getTileTypeID(layerTile, tmxPath, layerID)
+	if layerTile.Nil {
+		return
+	}
+	name := nameForLayerTile(layerTile)
+	tileTypeID, ok := world.IDFor(name)
+	if !ok {
+		tileTypeID, ok = tileTypeIDs[name]
+		if !ok {
+			log.Fatalf("cannot found tile type ID for %v", name)
+		}
+	}
 	if tileTypeID != world.TileTypeIDAir {
 
 		// correct mismatch between Tiled Y axis (downwards)
 		// and our Y axis  (upwards)
 		y := int(planet.Height) - tileIndex/int(planet.Width)
 		x := tileIndex % int(planet.Width)
-		planet.PlaceTileType(tileTypeID, x, y)
+
+		opts := world.NewTileCreationOptions()
+		flipX, flipY := scaleFromFlipFlags(layerTile)
+		opts.FlipTransform = mgl32.Scale3D(float32(flipX), float32(flipY), 1)
+		planet.PlaceTileType(tileTypeID, x, y, opts)
 	}
 }
 
 func importLayer(
 	planet *world.Planet, tiledLayer *tiled.Layer, tmxPath string,
-	layerID world.LayerID,
+	layerID world.LayerID, tileTypeIDs map[string]world.TileTypeID,
 ) {
 	for idx, layerTile := range tiledLayer.Tiles {
-		importTile(planet, idx, layerTile, tmxPath, layerID)
+		importTile(planet, idx, layerTile, tmxPath, layerID, tileTypeIDs)
 	}
+}
+
+func filterTiledSpritesInMapLayers(
+	allTiledSprites TiledSprites, tiledMap *tiled.Map,
+) TiledSprites {
+	mapTiledSprites := TiledSprites{}
+	for _, layer := range tiledMap.Layers {
+		for _, layerTile := range layer.Tiles {
+			if !layerTile.Nil {
+				name := nameForLayerTile(layerTile)
+				layerID, _ := world.LayerIDForName(layer.Name)
+				mapTiledSprites[name] = allTiledSprites[name]
+				for idx := range mapTiledSprites[name] {
+					mapTiledSprites[name][idx].Metadata.LayerID = layerID
+				}
+			}
+		}
+	}
+
+	return mapTiledSprites
 }

--- a/world/lighting.go
+++ b/world/lighting.go
@@ -158,7 +158,7 @@ func (planet *Planet) InitSkyLight() {
 	for x := 0; x < int(planet.Width); x++ {
 		y := int(planet.Height) - 1
 		for ; y >= 0; y-- {
-			tile := planet.GetTile(x, y, TopLayer)
+			tile,_ := planet.GetTile(x, y, TopLayer)
 			//tile not empty
 			if tile.Name != "" {
 				break
@@ -174,7 +174,7 @@ func (planet *Planet) InitSkyLight() {
 
 			topTileIdx := planet.GetTileIndex(x, y+1)
 			topTileValue := planet.LightingValues[topTileIdx]
-			lightTile := planet.GetTile(x, y, TopLayer)
+			lightTile,_ := planet.GetTile(x, y, TopLayer)
 
 			attenuation := uint8(getLightAttenuation(lightTile))
 			//avoid overflow
@@ -206,7 +206,7 @@ func (planet *Planet) LightUpdateBlock(xtile, yTile int) {
 		return
 	}
 
-	tile := planet.GetTile(xtile, yTile, TopLayer)
+	tile,_ := planet.GetTile(xtile, yTile, TopLayer)
 	tileType, ok := GetTileTypeByID(tile.TileTypeID)
 	if ok && tile.LightSource {
 		if tileType.LightAmount > 15 {
@@ -263,7 +263,7 @@ func (planet *Planet) UpdateSkyLight(iterations int) {
 
 		}
 		lightVal := planet.LightingValues[idx]
-		lightTile := planet.GetTile(pos.X, pos.Y, TopLayer)
+		lightTile,_ := planet.GetTile(pos.X, pos.Y, TopLayer)
 		lightSkyLightValue := lightVal.GetSkyLight()
 
 		topTileIdx := planet.GetTileIndex(pos.X, pos.Y+1)
@@ -272,7 +272,7 @@ func (planet *Planet) UpdateSkyLight(iterations int) {
 		}
 
 		topTileLightValue := planet.LightingValues[topTileIdx]
-		topTile := planet.GetTile(pos.X, pos.Y+1, TopLayer)
+		topTile,_ := planet.GetTile(pos.X, pos.Y+1, TopLayer)
 
 		attenuation := uint8(getLightAttenuation(lightTile))
 		//placed solid block below sunlight
@@ -399,7 +399,7 @@ func (planet *Planet) UpdateEnvLight(iterations int) {
 
 		}
 		lightVal := planet.LightingValues[idx]
-		lightTile := planet.GetTile(pos.X, pos.Y, TopLayer)
+		lightTile,_ := planet.GetTile(pos.X, pos.Y, TopLayer)
 
 		envLightValue := lightVal.GetEnvLight()
 

--- a/world/lightplacer.go
+++ b/world/lightplacer.go
@@ -1,0 +1,39 @@
+package world
+
+import (
+	"log"
+
+	"github.com/skycoin/cx-game/render"
+)
+
+type LightPlacer struct {
+	Tile                    Tile
+	OnSpriteID, OffSpriteID render.SpriteID
+}
+
+func (placer LightPlacer) CreateTile(
+	tt TileType, opts TileCreationOptions,
+) Tile {
+	tile := placer.Tile
+	updateOpts := TileUpdateOptions{
+		Tile: &tile,
+	}
+	placer.UpdateTile(tt, updateOpts)
+	return tile
+}
+
+func (placer LightPlacer) UpdateTile(
+	tt TileType, opts TileUpdateOptions,
+) {
+	if opts.Tile.Power.On {
+		opts.Tile.SpriteID = placer.OnSpriteID
+	} else {
+		opts.Tile.SpriteID = placer.OffSpriteID
+	}
+	log.Printf("LightPlacer set spriteID to %v", opts.Tile.SpriteID)
+	log.Printf("On=%v, Off=%v", placer.OnSpriteID, placer.OffSpriteID)
+}
+
+func (placer LightPlacer) ItemSpriteID() render.SpriteID {
+	return placer.OnSpriteID
+}

--- a/world/mapgen/generate.go
+++ b/world/mapgen/generate.go
@@ -34,7 +34,8 @@ func placeLayer(
 		height := int(depth + noiseSample*noiseScale)
 		for i := 0; i < height; i++ {
 			y := planet.GetHeight(int(x)) + 1
-			planet.PlaceTileType(tileTypeID, int(x), int(y))
+			opts := world.NewTileCreationOptions()
+			planet.PlaceTileType(tileTypeID, int(x), int(y), opts)
 			positions = append(positions, cxmath.Vec2i{x, int32(y)})
 		}
 	}
@@ -62,7 +63,8 @@ func placeOres(planet *world.Planet, tile world.Tile, threshold float32) {
 func placeBgTile(
 	planet *world.Planet, tileTypeID world.TileTypeID, pos cxmath.Vec2i,
 ) {
-	planet.PlaceTileType(tileTypeID, int(pos.X), int(pos.Y))
+	opts := world.NewTileCreationOptions()
+	planet.PlaceTileType(tileTypeID, int(pos.X), int(pos.Y), opts)
 }
 
 func placePoles(planet *world.Planet) {
@@ -84,11 +86,13 @@ func idFor(name string) world.TileTypeID {
 const poleRadius int = 4
 
 func placePole(planet *world.Planet, origin int) {
+	opts := world.NewTileCreationOptions()
+
 	for x := origin - poleRadius; x < origin+poleRadius; x++ {
 		for y := 0; y < int(planet.Height); y++ {
-			tile := planet.GetTile(x, y, world.TopLayer)
+			tile,_ := planet.GetTile(x, y, world.TopLayer)
 			if tile.TileTypeID == idFor("regolith") {
-				planet.PlaceTileType(idFor("methane-ice"), x, y)
+				planet.PlaceTileType(idFor("methane-ice"), x, y, opts)
 			}
 		}
 	}

--- a/world/placer.go
+++ b/world/placer.go
@@ -1,0 +1,35 @@
+package world
+
+import (
+	"github.com/skycoin/cx-game/render"
+)
+
+type Placer interface {
+	CreateTile(TileType, TileCreationOptions) Tile
+	UpdateTile(TileType, TileUpdateOptions)
+	ItemSpriteID() render.SpriteID
+}
+
+// place tiles for a tiletype which has a single sprite
+type DirectPlacer struct {
+	SpriteID render.SpriteID
+	Tile     Tile
+}
+
+func (placer DirectPlacer) CreateTile(
+	tt TileType, opts TileCreationOptions,
+) Tile {
+	tile := placer.Tile
+	tile.SpriteID = placer.SpriteID
+	tile.FlipTransform = opts.FlipTransform
+	return tile
+}
+
+// nothing to update
+func (placer DirectPlacer) UpdateTile(
+	tt TileType, opts TileUpdateOptions) {
+}
+
+func (placer DirectPlacer) ItemSpriteID() render.SpriteID {
+	return placer.SpriteID
+}

--- a/world/planet.go
+++ b/world/planet.go
@@ -106,12 +106,13 @@ func (planet *Planet) ShortestDisplacement(from, to mgl32.Vec2) mgl32.Vec2 {
 	return disp
 }
 
-func (planet *Planet) GetTile(x, y int, layerID LayerID) *Tile {
+func (planet *Planet) GetTile(x, y int, layerID LayerID) (*Tile,bool) {
 	idx := planet.GetTileIndex(x, y)
 	if idx >= 0 {
-		return &planet.GetLayerTiles(layerID)[planet.GetTileIndex(x, y)]
+		tile := &planet.GetLayerTiles(layerID)[planet.GetTileIndex(x, y)]
+		return tile, true
 	} else {
-		return nil
+		return nil, false
 	}
 }
 
@@ -128,7 +129,9 @@ func (planet *Planet) GetAllTilesUnique() []Tile {
 	return tiles
 }
 
-func (planet *Planet) PlaceTileTypeNoConnect(tileTypeID TileTypeID, x, y int) {
+func (planet *Planet) PlaceTileTypeNoConnect(
+		tileTypeID TileTypeID, x, y int, opts TileCreationOptions,
+) {
 	tileType, ok := GetTileTypeByID(tileTypeID)
 	if !ok {
 		log.Fatalf("cannot find tile type for id [%v]", tileTypeID)
@@ -138,10 +141,7 @@ func (planet *Planet) PlaceTileTypeNoConnect(tileTypeID TileTypeID, x, y int) {
 	if rootTileIdx == -1 {
 		return
 	}
-	tilesInLayer[rootTileIdx] =
-		tileType.CreateTile(TileCreationOptions{
-			//Neighbours: planet.GetNeighbours(tilesInLayer, x, y, tileTypeID),
-		})
+	tilesInLayer[rootTileIdx] = tileType.CreateTile(opts)
 	rect := cxmath.Rect{
 		cxmath.Vec2i{int32(x), int32(y)},
 		tileType.Size(),
@@ -171,13 +171,15 @@ func (planet *Planet) PlaceTileTypeNoConnect(tileTypeID TileTypeID, x, y int) {
 	planet.LightUpdateBlock(x, y)
 }
 
-func (planet *Planet) PlaceTileType(tileTypeID TileTypeID, x, y int) {
+func (planet *Planet) PlaceTileType(
+		tileTypeID TileTypeID, x, y int, opts TileCreationOptions,
+) {
 	tileType, ok := GetTileTypeByID(tileTypeID)
 	if !ok {
 		log.Fatalf("cannot find tile type for id [%v]", tileTypeID)
 	}
 	tilesInLayer := planet.GetLayerTiles(tileType.Layer)
-	planet.PlaceTileTypeNoConnect(tileTypeID, x, y)
+	planet.PlaceTileTypeNoConnect(tileTypeID, x, y, opts)
 	rect := cxmath.Rect{
 		cxmath.Vec2i{int32(x), int32(y)},
 		tileType.Size(),

--- a/world/power.go
+++ b/world/power.go
@@ -1,0 +1,9 @@
+package world
+
+func (planet *Planet) TogglePower(x,y int, on bool) {
+	tile,ok := planet.GetTile(x,y, MidLayer)
+	if !ok { return }
+	tile.Power.On = on
+	tilesInLayer := planet.GetLayerTiles(MidLayer)
+	planet.updateTile(tilesInLayer, x,y)
+}

--- a/world/tile.go
+++ b/world/tile.go
@@ -1,6 +1,8 @@
 package world
 
 import (
+	"github.com/go-gl/mathgl/mgl32"
+
 	"github.com/skycoin/cx-game/render"
 )
 
@@ -37,6 +39,13 @@ type Tile struct {
 	Connections       Connections
 	LightSource       bool
 	NeedsGround       bool
+	Power             TilePower
+
+	FlipTransform     mgl32.Mat4
+}
+
+type TilePower struct {
+	On bool
 }
 
 func NewEmptyTile() Tile {
@@ -48,5 +57,6 @@ func NewNormalTile() Tile {
 		TileCategory:      TileCategoryNormal,
 		TileCollisionType: TileCollisionTypeSolid,
 		Durability:        1,
+		FlipTransform:     mgl32.Ident4(),
 	}
 }

--- a/world/tiletype.go
+++ b/world/tiletype.go
@@ -9,35 +9,6 @@ import (
 	"github.com/skycoin/cx-game/world/tiling"
 )
 
-type Placer interface {
-	CreateTile(TileType, TileCreationOptions) Tile
-	UpdateTile(TileType, TileUpdateOptions)
-	ItemSpriteID() render.SpriteID
-}
-
-// place tiles for a tiletype which has a single sprite
-type DirectPlacer struct {
-	SpriteID render.SpriteID
-	Tile     Tile
-}
-
-func (placer DirectPlacer) CreateTile(
-	tt TileType, opts TileCreationOptions,
-) Tile {
-	tile := placer.Tile
-	tile.SpriteID = placer.SpriteID
-	return tile
-}
-
-// nothing to update
-func (placer DirectPlacer) UpdateTile(
-	tt TileType, opts TileUpdateOptions) {
-}
-
-func (placer DirectPlacer) ItemSpriteID() render.SpriteID {
-	return placer.SpriteID
-}
-
 type TileTypeID uint32
 type TileType struct {
 	Name          string
@@ -72,7 +43,15 @@ func (tt *TileType) Transform() mgl32.Mat4 {
 
 type TileCreationOptions struct {
 	Neighbours tiling.DetailedNeighbours
+	FlipTransform mgl32.Mat4
 }
+
+func NewTileCreationOptions() TileCreationOptions {
+	return TileCreationOptions {
+		FlipTransform: mgl32.Ident4(),
+	}
+}
+
 type TileUpdateOptions struct {
 	Neighbours tiling.DetailedNeighbours
 	Tile       *Tile


### PR DESCRIPTION
closes #524 

See for yourself with in-game command `tp 77 112 on` within Moon Bunker map ( which is loaded by default).

![Screenshot from 2021-11-10 14-08-35](https://user-images.githubusercontent.com/8276517/141177496-dccdb516-8ec1-404a-a7cc-9e2f28197ae0.png)

# Changes

- manually specified Tiled tiles load properly
- light turns on and off with "power" in-game command
- register all tiled sprites found in map
- sprites flip but use same SpriteID
- add flip to tile creation options
- separate tile and sprite registration during Tiled import
- Planet.GetTile() now additionally returns an "ok" value
- add console command for toggling power state
- adjust spawn position to center of moon bunker map