### PR TITLE
Needs ground

### DIFF
--- a/assets/luis/tiled files/Objects.tsx
+++ b/assets/luis/tiled files/Objects.tsx
@@ -2,81 +2,154 @@
 <tileset version="1.5" tiledversion="1.7.2" name="Objects" tilewidth="112" tileheight="128" tilecount="33" columns="0">
  <grid orientation="orthogonal" width="1" height="1"/>
  <tile id="0">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="48" height="64" source="../computers/controlStation1.png"/>
  </tile>
  <tile id="1">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="112" height="64" source="../computers/controlStation2.png"/>
  </tile>
  <tile id="2">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="32" height="64" source="../gas_machines/algaeTank2.png"/>
  </tile>
  <tile id="3">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="48" height="48" source="../gas_machines/gasPump_3x3.png"/>
  </tile>
  <tile id="4">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="16" height="16" source="../gas_machines/vent1.png"/>
  </tile>
  <tile id="5">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="48" height="64" source="../power_machines/battery3.png"/>
  </tile>
  <tile id="6">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="32" height="48" source="../power_machines/battery4.png"/>
  </tile>
  <tile id="7">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="32" height="64" source="../power_machines/solarGenerator1.png"/>
  </tile>
  <tile id="8">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="64" height="64" source="../power_machines/solarPanel4.png"/>
  </tile>
  <tile id="9">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="32" height="16" source="../plants/plant_1.png"/>
  </tile>
  <tile id="10">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="32" height="32" source="../plants/plant_2.png"/>
  </tile>
  <tile id="11">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="32" height="16" source="../plants/pot_1.png"/>
  </tile>
  <tile id="12">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="80" height="32" source="../furniture/seats/bed1.png"/>
  </tile>
  <tile id="13">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="32" height="32" source="../furniture/seats/chair1.png"/>
  </tile>
  <tile id="14">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="32" height="48" source="../furniture/seats/chair3.png"/>
  </tile>
  <tile id="15">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="32" height="16" source="../furniture/decorations/roofScreen.png"/>
  </tile>
  <tile id="16">
   <properties>
    <property name="cxtile" value="decorations/spare-suit"/>
+   <property name="needsground" type="bool" value="true"/>
   </properties>
   <image width="32" height="48" source="../furniture/decorations/spareSuit.png"/>
  </tile>
  <tile id="17">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="48" height="48" source="../liquid_machines/waterPump_3x3.png"/>
  </tile>
  <tile id="18">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="64" height="80" source="../radar/radar.png"/>
  </tile>
  <tile id="19">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="32" height="16" source="../turrets/roofLaser.png"/>
  </tile>
  <tile id="20">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="48" height="32" source="../turrets/Turret1.png"/>
  </tile>
  <tile id="21">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="48" height="32" source="../containers/animalCage.png"/>
  </tile>
  <tile id="22">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="32" height="32" source="../containers/chest.png"/>
  </tile>
  <tile id="23">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="32" height="32" source="../containers/metalBox_blue.png"/>
  </tile>
  <tile id="24">
+  <properties>
+   <property name="needsground" type="bool" value="true"/>
+  </properties>
   <image width="32" height="32" source="../containers/metalBox_orange.png"/>
  </tile>
  <tile id="25">

--- a/world/import/register_sprites.go
+++ b/world/import/register_sprites.go
@@ -36,6 +36,7 @@ type TiledMetadata struct {
 	Powered OptionalBool
 	Name    string
 	LayerID world.LayerID
+	NeedsGround bool
 }
 
 func NewTiledMetadata(name string) TiledMetadata {
@@ -129,6 +130,7 @@ func (metadata *TiledMetadata) ParseFrom(properties tiled.Properties) {
 	if hasProperty(properties, "cxtile") {
 		metadata.Name = properties.GetString("cxtile")
 	}
+	metadata.NeedsGround = properties.GetBool("needsground")
 }
 
 func parseMetadataFromLayerTile(layerTile *tiled.LayerTile) TiledMetadata {

--- a/world/import/tile.go
+++ b/world/import/tile.go
@@ -98,6 +98,7 @@ func registerTileTypeForTileSprites(
 		Width: tileSprites[0].Width, Height: tileSprites[0].Height,
 		Placer: placerForTileSprites(tileSprites),
 		Layer:  layerID,
+		NeedsGround: tileSprites[0].Metadata.NeedsGround,
 	}
 
 	tileTypeID :=


### PR DESCRIPTION
closes #522 

Tiled importer now respects the "needsground" property on Tileset tiles. Set this property on future tiles to restrict them to only be placed on the ground.