### PR TITLE
Hangable light placement restriction

### DIFF
--- a/assets/luis/tiled files/Objects.tsx
+++ b/assets/luis/tiled files/Objects.tsx
@@ -94,7 +94,7 @@
  </tile>
  <tile id="15">
   <properties>
-   <property name="needsground" type="bool" value="true"/>
+   <property name="needsroof" type="bool" value="true"/>
   </properties>
   <image width="32" height="16" source="../furniture/decorations/roofScreen.png"/>
  </tile>
@@ -119,7 +119,7 @@
  </tile>
  <tile id="19">
   <properties>
-   <property name="needsground" type="bool" value="true"/>
+   <property name="needsroof" type="bool" value="true"/>
   </properties>
   <image width="32" height="16" source="../turrets/roofLaser.png"/>
  </tile>
@@ -154,6 +154,9 @@
   <image width="32" height="32" source="../containers/metalBox_orange.png"/>
  </tile>
  <tile id="25">
+  <properties>
+   <property name="needsroof" type="bool" value="true"/>
+  </properties>
   <image width="16" height="16" source="../furniture/decorations/surveillanceCamera.png"/>
  </tile>
  <tile id="26">
@@ -173,15 +176,24 @@
   <image width="16" height="16" source="../lights/light_1_on.png"/>
  </tile>
  <tile id="28">
+  <properties>
+   <property name="needsroof" type="bool" value="true"/>
+  </properties>
   <image width="48" height="16" source="../lights/light_2_off.png"/>
  </tile>
  <tile id="29">
+  <properties>
+   <property name="needsroof" type="bool" value="true"/>
+  </properties>
   <image width="48" height="16" source="../lights/light_2_on.png"/>
  </tile>
  <tile id="30">
   <image width="16" height="16" source="../lights/light_3_cable.png"/>
  </tile>
  <tile id="31">
+  <properties>
+   <property name="needsroof" type="bool" value="true"/>
+  </properties>
   <image width="16" height="32" source="../lights/light_3_on.png"/>
  </tile>
  <tile id="32">

--- a/assets/tile/furnitures.yaml
+++ b/assets/tile/furnitures.yaml
@@ -155,17 +155,4 @@ lights/light_1_off:
     height: 1
     layer: mid
 
-lights/light_2_on:
-    sprite: lights/light_2_on
-    durability: 5
-    width: 3
-    height: 1
-    layer: mid
-
-lights/light_2_off:
-    sprite: lights/light_2_off
-    durability: 5
-    width: 3
-    height: 1
-    layer: mid
 ---

--- a/item/canplace.go
+++ b/item/canplace.go
@@ -1,0 +1,36 @@
+package item
+
+import (
+	"github.com/skycoin/cx-game/world"
+)
+
+func CanPlaceTileTypeAt(World *world.World, tt *world.TileType, x,y int) bool {
+	//midlayer and toplayer can't occupy same tile
+	layersToCheck := layersToCheckForPlace(tt.Layer)
+	occupyingTilesAreClear :=
+		tilesAreClear(World,layersToCheck,x,y,x+int(tt.Width),y+int(tt.Height))
+
+	wouldBeSupported := tileTypeWouldBeSupported(World,tt,x,y)
+
+	return occupyingTilesAreClear && wouldBeSupported
+}
+
+func tileTypeWouldBeSupported(
+	World *world.World,tt *world.TileType, x,y int,
+) bool {
+	if tt.NeedsGround {
+		belowTilesAreSolid := tilesAreSolid(
+			World, []world.LayerID { world.TopLayer },
+			x,y-1,x+int(tt.Width),y,
+		)
+		if !belowTilesAreSolid { return false }
+	}
+	if tt.NeedsRoof {
+		aboveTilesAreSolid := tilesAreSolid(
+			World, []world.LayerID { world.TopLayer },
+			x,y+int(tt.Height),x+int(tt.Width),y+int(tt.Height)+1,
+		)
+		if !aboveTilesAreSolid { return false }
+	}
+	return true
+}

--- a/item/placement-grid.go
+++ b/item/placement-grid.go
@@ -299,17 +299,5 @@ func (grid *PlacementGrid) UpdatePreview(
 
 	tt := grid.Selected.Get()
 
-	//midlayer and toplayer can't occupy same tile
-	layersToCheck := layersToCheckForPlace(tt.Layer)
-	occupyingTilesAreClear :=
-		tilesAreClear(World,layersToCheck,x,y,x+int(tt.Width),y+int(tt.Height))
-
-	grid.canPlace = occupyingTilesAreClear
-	if tt.NeedsGround {
-		belowTilesAreSolid := tilesAreSolid(
-			World, []world.LayerID { world.TopLayer },
-			x,y-1,x+int(tt.Width),y,
-		)
-		grid.canPlace = grid.canPlace && belowTilesAreSolid
-	}
+	grid.canPlace = CanPlaceTileTypeAt(World,tt,x,y)
 }

--- a/world/import/metadata.go
+++ b/world/import/metadata.go
@@ -13,7 +13,7 @@ type TiledMetadata struct {
 	Powered OptionalBool
 	Name    string
 	LayerID world.LayerID
-	NeedsGround bool
+	NeedsGround, NeedsRoof bool
 	Wattage int
 }
 
@@ -43,6 +43,7 @@ func (metadata *TiledMetadata) ParseFrom(properties tiled.Properties) {
 		metadata.Name = properties.GetString("cxtile")
 	}
 	metadata.NeedsGround = properties.GetBool("needsground")
+	metadata.NeedsRoof = properties.GetBool("needsroof")
 	metadata.Wattage = properties.GetInt("wattage")
 }
 

--- a/world/import/tile.go
+++ b/world/import/tile.go
@@ -101,6 +101,7 @@ func registerTileTypeForTileSprites(
 		Placer: placerForTileSprites(tileSprites),
 		Layer:  layerID,
 		NeedsGround: tileSprites[0].Metadata.NeedsGround,
+		NeedsRoof: tileSprites[0].Metadata.NeedsRoof,
 	}
 
 	tileTypeID :=

--- a/world/tiletype.go
+++ b/world/tiletype.go
@@ -23,7 +23,7 @@ type TileType struct {
 	ItemSpriteID  render.SpriteID
 	LightSource   bool
 	LightAmount   uint8 // from 0 to 15
-	NeedsGround   bool
+	NeedsGround, NeedsRoof   bool
 }
 
 func (tt TileType) Size() cxmath.Vec2i {


### PR DESCRIPTION
closes #551

https://user-images.githubusercontent.com/8276517/144128805-643c6d1b-6b1f-4d25-a32b-25c7abd1e9fc.mp4

# Changes
- remove redundant tiletype
- add 'needsroof' check during tile place
- add 'needsroof' property to Tiled Tileset tiles