### PR TITLE
Import ores

### DIFF
--- a/assets/luis/tiled files/Tiles_1.tsx
+++ b/assets/luis/tiled files/Tiles_1.tsx
@@ -56,61 +56,6 @@
    <property name="cxtile" value="regolith"/>
   </properties>
  </tile>
- <tile id="11">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="12">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="13">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="14">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="15">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="16">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="17">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="18">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="19">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="20">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="21">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
  <tile id="22">
   <properties>
    <property name="cxtile" value="regolith"/>
@@ -164,61 +109,6 @@
  <tile id="32">
   <properties>
    <property name="cxtile" value="regolith"/>
-  </properties>
- </tile>
- <tile id="33">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="34">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="35">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="36">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="37">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="38">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="39">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="40">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="41">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="42">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="43">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
   </properties>
  </tile>
  <tile id="44">
@@ -276,61 +166,6 @@
    <property name="cxtile" value="regolith"/>
   </properties>
  </tile>
- <tile id="55">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="56">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="57">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="58">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="59">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="60">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="61">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="62">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="63">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="64">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="65">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
  <tile id="66">
   <properties>
    <property name="cxtile" value="regolith"/>
@@ -386,61 +221,6 @@
    <property name="cxtile" value="regolith"/>
   </properties>
  </tile>
- <tile id="77">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="78">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="79">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="80">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="81">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="82">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="83">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="84">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="85">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="86">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="87">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
  <tile id="88">
   <properties>
    <property name="cxtile" value="regolith"/>
@@ -494,61 +274,6 @@
  <tile id="98">
   <properties>
    <property name="cxtile" value="regolith"/>
-  </properties>
- </tile>
- <tile id="99">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="100">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="101">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="102">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="103">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="104">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="105">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="106">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="107">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="108">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
-  </properties>
- </tile>
- <tile id="109">
-  <properties>
-   <property name="cxtile" value="methane-ice"/>
   </properties>
  </tile>
  <tile id="110">

--- a/assets/tile/tiles.yaml
+++ b/assets/tile/tiles.yaml
@@ -52,10 +52,6 @@ smoothplatform:
 #         - tiles/platform
 #     layer: top
 
-methane-ice:
-    sprite: tiles/methane-ice
-    layer: top
-
 regolith-wall:
     blob: full
     sprites: 

--- a/world/layer.go
+++ b/world/layer.go
@@ -52,7 +52,9 @@ var layerIDsByName = map[string]LayerID{
 	"windows":    WindowLayer,
 	"walls":      BgLayer,
 	"pipesim":    PipeLayer,
+	// multiple Tiled layers map to the in-game SuperLayer
 	"fluids":     SuperLayer,
+	"ores":       SuperLayer,
 }
 
 func LayerIDForName(name string) (LayerID, bool) {


### PR DESCRIPTION
closes #555 

Still need to associate with cxtile and detect blob tiling in a future pull request

# Changes
- remove cxtile association as a hotfix for importing blob tiles
- remove deprecated methane-ice TileType YAML entry
- wall-attached ores import